### PR TITLE
Simplified override agent core controllers in custom code

### DIFF
--- a/examples/spring-ai-override-invocations/Dockerfile
+++ b/examples/spring-ai-override-invocations/Dockerfile
@@ -1,0 +1,22 @@
+FROM --platform=linux/arm64 amazoncorretto:21-alpine
+
+# Create non-root user
+RUN addgroup -S appuser && adduser -S appuser -G appuser
+
+# Set working directory
+WORKDIR /app
+
+# Copy JAR file
+COPY target/sse-agents-0.0.1-SNAPSHOT.jar app.jar
+
+# Change ownership to non-root user
+RUN chown appuser:appuser /app/app.jar
+
+# Switch to non-root user
+USER appuser
+
+# Expose port
+EXPOSE 8080
+
+# Use exec form (container support is default in JDK 21)
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/examples/spring-ai-override-invocations/README.md
+++ b/examples/spring-ai-override-invocations/README.md
@@ -1,0 +1,60 @@
+# Spring AI Override Invocations
+
+This example demonstrates how to override `AgentCoreInvocationsController` from the `spring-ai-bedrock-agentcore-starter` while still benefiting from the ping endpoint functionality.
+
+## Features
+
+- **Custom Controller Override**: Extends `AgentCoreInvocationsController` to provide custom invocation handling
+- **Ping Endpoint Reuse**: Leverages the built-in `/ping` endpoint from the starter for health monitoring
+- **Spring AI Integration**: Direct integration with ChatClient for AI responses
+- **Selective Starter Benefits**: Uses only the ping functionality while customizing the invocations endpoint
+
+## What This Example Shows
+
+The example demonstrates how to:
+
+1. **Override the invocations controller** using marker interface approach
+2. **Implement custom request handling** without inheritance constraints
+3. **Maintain health monitoring** through the existing ping endpoint
+4. **Integrate directly with Spring AI** ChatClient
+5. **Zero configuration needed** - just implement the marker interface
+
+```java
+@RestController
+public class CustomController implements AgentCoreInvocationsHandler {
+    
+    @PostMapping(value = "/invocations", consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<String> handleJsonInvocation(@RequestBody Object request, @RequestHeader HttpHeaders headers) {
+        return chatClient.prompt().user((String) request).stream().content();
+    }
+}
+```
+
+## How It Works
+
+1. **Marker Interface**: `CustomController` implements `AgentCoreInvocationsHandler`
+2. **Auto-Discovery**: Spring finds the controller via `@RestController` annotation
+3. **Conditional Skip**: `@ConditionalOnMissingBean(AgentCoreInvocationsHandler.class)` prevents auto-configuration
+4. **No Configuration**: No need for `@Configuration` classes or manual bean definitions
+
+## API Endpoints
+
+- **Custom invocations**: `POST /invocations` - Custom AI processing with streaming response
+- **Health monitoring**: `GET /ping` - Built-in health check from the starter
+
+## Benefits
+
+- **Zero configuration**: Just implement the marker interface and add `@RestController`
+- **No inheritance constraints**: Complete freedom in method signatures and mappings
+- **Selective feature usage**: Use only the ping endpoint from the starter
+- **Full control**: Complete control over request/response handling
+- **No annotation constraints**: No need for `@AgentCoreInvocation` annotation
+- **Direct Spring AI access**: Direct ChatClient integration without method discovery overhead
+
+## Requirements
+
+- Java 21+
+- Spring Boot 3.x
+- Spring AI
+- Amazon Bedrock access

--- a/examples/spring-ai-override-invocations/pom.xml
+++ b/examples/spring-ai-override-invocations/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.4.5</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.unicorn</groupId>
+	<artifactId>spring-ai-override-invocations</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<name>spring-ai-override-invocations</name>
+	<description>Spring AI AgentCore Controller Override Example</description>
+	<properties>
+		<java.version>21</java.version>
+		<spring-ai.version>1.0.0</spring-ai.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
+		</dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-bedrock-agentcore-starter</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-bom</artifactId>
+				<version>${spring-ai.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+
+	</dependencyManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/examples/spring-ai-override-invocations/src/main/java/com/unicorn/OverrideInvocationsApplication.java
+++ b/examples/spring-ai-override-invocations/src/main/java/com/unicorn/OverrideInvocationsApplication.java
@@ -1,0 +1,13 @@
+package com.unicorn;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OverrideInvocationsApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(OverrideInvocationsApplication.class, args);
+	}
+
+}

--- a/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/CustomAgentCoreInvocationsController.java
+++ b/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/CustomAgentCoreInvocationsController.java
@@ -1,0 +1,29 @@
+package com.unicorn.agents;
+
+import org.springaicommunity.agentcore.controller.AgentCoreInvocationsHandler;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+@RestController
+public class CustomAgentCoreInvocationsController implements AgentCoreInvocationsHandler {
+
+    private final ChatClient chatClient;
+
+    public CustomAgentCoreInvocationsController(ChatClient.Builder chatClient) {
+        this.chatClient = chatClient
+                .defaultTools(new DateTimeTools())
+                .build();
+    }
+
+    @PostMapping(value = "/invocations", consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<String> handleJsonInvocation(@RequestBody Object request, @RequestHeader HttpHeaders headers) {
+        return chatClient.prompt().user((String) request).stream().content();
+    }
+}

--- a/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/DateTimeTools.java
+++ b/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/DateTimeTools.java
@@ -1,0 +1,14 @@
+package com.unicorn.agents;
+
+import java.time.LocalDateTime;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.context.i18n.LocaleContextHolder;
+
+class DateTimeTools {
+
+    @Tool(description = "Get the current date and time in the user's timezone")
+    String getCurrentDateTime(String param) {
+        return LocalDateTime.now().atZone(LocaleContextHolder.getTimeZone().toZoneId()).toString();
+    }
+
+}

--- a/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/PromptRequest.java
+++ b/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/PromptRequest.java
@@ -1,0 +1,3 @@
+package com.unicorn.agents;
+
+public record PromptRequest(String prompt){}

--- a/examples/spring-ai-override-invocations/src/main/resources/application.properties
+++ b/examples/spring-ai-override-invocations/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.application.name=sse-agents
+spring.ai.bedrock.aws.region=eu-west-1
+spring.ai.bedrock.converse.chat.options.model=eu.anthropic.claude-sonnet-4-20250514-v1:0

--- a/examples/spring-ai-override-invocations/src/test/java/com/unicorn/agents/OverrideInvocationsApplicationTests.java
+++ b/examples/spring-ai-override-invocations/src/test/java/com/unicorn/agents/OverrideInvocationsApplicationTests.java
@@ -1,0 +1,13 @@
+package com.unicorn.agents;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class OverrideInvocationsApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/examples/spring-ai-override-invocations/test_request.http
+++ b/examples/spring-ai-override-invocations/test_request.http
@@ -1,0 +1,5 @@
+POST http://localhost:8080/invocations
+Content-Type: application/json
+Accept: application/octet-stream
+
+"Tell me about Spring AI in detail."

--- a/spring-ai-bedrock-agentcore-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreAutoConfiguration.java
+++ b/spring-ai-bedrock-agentcore-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreAutoConfiguration.java
@@ -19,7 +19,9 @@ package org.springaicommunity.agentcore.autoconfigure;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springaicommunity.agentcore.annotation.AgentCoreInvocation;
 import org.springaicommunity.agentcore.controller.AgentCoreInvocationsController;
+import org.springaicommunity.agentcore.controller.AgentCoreInvocationsHandler;
 import org.springaicommunity.agentcore.controller.AgentCorePingController;
+import org.springaicommunity.agentcore.controller.AgentCorePingHandler;
 import org.springaicommunity.agentcore.ping.AgentCorePingService;
 import org.springaicommunity.agentcore.ping.AgentCoreTaskTracker;
 import org.springaicommunity.agentcore.service.AgentCoreMethodInvoker;
@@ -57,9 +59,8 @@ public class AgentCoreAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean
-	public AgentCoreInvocationsController agentCoreController(AgentCoreMethodInvoker invoker,
-			AgentCoreTaskTracker agentCoreTaskTracker) {
+	@ConditionalOnMissingBean(AgentCoreInvocationsHandler.class)
+	public AgentCoreInvocationsController agentCoreController(AgentCoreMethodInvoker invoker) {
 		return new AgentCoreInvocationsController(invoker);
 	}
 
@@ -70,7 +71,7 @@ public class AgentCoreAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean
+	@ConditionalOnMissingBean(AgentCorePingHandler.class)
 	public AgentCorePingController agentCoreHealthController(AgentCorePingService agentCorePingService) {
 		return new AgentCorePingController(agentCorePingService);
 	}

--- a/spring-ai-bedrock-agentcore-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCoreInvocationsController.java
+++ b/spring-ai-bedrock-agentcore-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCoreInvocationsController.java
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 @RestController
-public class AgentCoreInvocationsController {
+public class AgentCoreInvocationsController implements AgentCoreInvocationsHandler {
 
 	private final AgentCoreMethodInvoker invoker;
 

--- a/spring-ai-bedrock-agentcore-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCoreInvocationsHandler.java
+++ b/spring-ai-bedrock-agentcore-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCoreInvocationsHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.controller;
+
+/**
+ * Marker interface for AgentCore invocations controllers. Implement this interface to
+ * provide custom invocation handling and prevent the auto-configured controller from
+ * being created.
+ */
+public interface AgentCoreInvocationsHandler {
+
+}

--- a/spring-ai-bedrock-agentcore-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCorePingController.java
+++ b/spring-ai-bedrock-agentcore-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCorePingController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
  * REST controller implementing the AgentCore /ping health check endpoint.
  */
 @RestController
-public class AgentCorePingController {
+public class AgentCorePingController implements AgentCorePingHandler {
 
 	private final AgentCorePingService agentCorePingService;
 

--- a/spring-ai-bedrock-agentcore-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCorePingHandler.java
+++ b/spring-ai-bedrock-agentcore-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCorePingHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.controller;
+
+/**
+ * Marker interface for AgentCore ping controllers. Implement this interface to provide
+ * custom ping/health handling and prevent the auto-configured ping controller from being
+ * created.
+ */
+public interface AgentCorePingHandler {
+
+}


### PR DESCRIPTION
PR simplifies overriding invocations or/and ping controllers in custom code by introduction marker interfaces: AgentCoreInvocationsHandler and AgentCorePingHandler