### PR TITLE
chore: upgrade Spring Boot 3.2.0 to 3.5.9 for Java 25 test compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
             <name>Andrei Shakirin</name>
             <email>andrei.shakirin@gmail.com</email>
         </developer>
+        <developer>
+            <name>Yuriy Bezsonov</name>
+            <email>ybezsonov@gmail.com</email>
+        </developer>
     </developers>
 
     <issueManagement>
@@ -63,7 +67,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <spring-boot.version>3.2.0</spring-boot.version>
+        <spring-boot.version>3.5.9</spring-boot.version>
         <bucket4j-core.version>8.7.0</bucket4j-core.version>
 
         <!-- plugin versions -->


### PR DESCRIPTION
Upgrades Spring Boot from 3.2.0 to 3.5.9 to enable running tests on Java 25.

Spring Boot 3.2.0 bundled ByteBuddy 1.14.x which doesn't support Java 25, causing Mockito test failures. Spring Boot 3.5.9 includes ByteBuddy 1.17.8 with native Java 25 support.