### PR TITLE
Improve build portability for spring-ai-extended-chat-client

### DIFF
--- a/examples/spring-ai-extended-chat-client/Dockerfile
+++ b/examples/spring-ai-extended-chat-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 amazoncorretto:21-alpine
+FROM amazoncorretto:21-alpine
 
 # Create non-root user
 RUN addgroup -S appuser && adduser -S appuser -G appuser
@@ -6,7 +6,7 @@ RUN addgroup -S appuser && adduser -S appuser -G appuser
 WORKDIR /app
 
 # Copy the jar file
-COPY target/spring-ai-extended-chat-client-1.0.0-SNAPSHOT.jar app.jar
+COPY target/spring-ai-extended-chat-client-*.jar app.jar
 
 # Change ownership
 RUN chown appuser:appuser /app/app.jar

--- a/examples/spring-ai-extended-chat-client/build-and-push.sh
+++ b/examples/spring-ai-extended-chat-client/build-and-push.sh
@@ -7,6 +7,39 @@ echo "🚀 Building and pushing Spring AI Extended Chat Client"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 REGION=$(aws configure get region || echo "us-east-1")
 
+# Detect CPU architecture
+HOST_ARCH=$(uname -m)
+TARGET_ARCH="arm64"
+
+# Normalize host architecture for comparison
+if [ "$HOST_ARCH" = "x86_64" ]; then
+    HOST_ARCH_NORMALIZED="amd64"
+elif [ "$HOST_ARCH" = "aarch64" ]; then
+    HOST_ARCH_NORMALIZED="arm64"
+else
+    HOST_ARCH_NORMALIZED="$HOST_ARCH"
+fi
+
+# Set up cross-platform build if needed
+if [ "$HOST_ARCH_NORMALIZED" != "$TARGET_ARCH" ]; then
+    echo "⚠️  Cross-platform build detected (${HOST_ARCH_NORMALIZED} → ${TARGET_ARCH})"
+    if ! docker buildx inspect --bootstrap 2>/dev/null | grep -q "linux/${TARGET_ARCH}"; then
+        echo "📦 Installing QEMU for cross-platform builds..."
+        docker run --privileged --rm tonistiigi/binfmt --install all
+        if [ $? -ne 0 ]; then
+            echo "❌ Error: Failed to install QEMU"
+            echo "   You can install it manually with:"
+            echo "   docker run --privileged --rm tonistiigi/binfmt --install all"
+            exit 1
+        fi
+        echo "✅ QEMU installed successfully"
+    else
+        echo "✅ QEMU already installed and configured"
+    fi
+else
+    echo "✅ Native ${TARGET_ARCH} build - no emulation needed"
+fi
+
 # Generate unique suffix for ECR repository
 SUFFIX=$(openssl rand -hex 4)
 ECR_REPO_NAME="spring-ai-extended-chat-client-${SUFFIX}"

--- a/examples/spring-ai-extended-chat-client/pom.xml
+++ b/examples/spring-ai-extended-chat-client/pom.xml
@@ -35,13 +35,13 @@
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-memory-bedrock-agentcore</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-RC5</version>
         </dependency>
 
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-bedrock-agentcore-starter</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-RC5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- Add CPU architecture detection and QEMU auto-setup to `build-and-push.sh` for cross-compiling arm64 images on x86_64 hosts
- Remove hardcoded `--platform=linux/arm64` from Dockerfile `FROM` (platform is controlled by `docker build --platform` instead)
- Use wildcard glob for jar `COPY` to avoid breaking on version changes
- Pin community dependencies (`spring-ai-memory-bedrock-agentcore`, `spring-ai-bedrock-agentcore-starter`) to `1.0.0-RC5`

## Test plan
- [ ] Build on an arm64 host and verify native build with no QEMU setup
- [ ] Build on an x86_64 host and verify QEMU is detected/installed and the cross-platform build succeeds
- [ ] Verify the Docker image starts correctly and the application runs
- [ ] Confirm `mvn clean package` produces a jar that matches the wildcard glob in the Dockerfile