### PR TITLE
Paginate deleteByConversationId to delete all events

### DIFF
--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/AgentCoreShortTermMemoryRepository.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/AgentCoreShortTermMemoryRepository.java
@@ -291,24 +291,38 @@ public class AgentCoreShortTermMemoryRepository implements ChatMemoryRepository 
 		try {
 			var actorAndSession = actorAndSession(conversationId);
 
-			var listEventsRequest = ListEventsRequest.builder()
-				.memoryId(memoryId)
-				.actorId(actorAndSession.actor())
-				.sessionId(actorAndSession.session())
-				.includePayloads(false)
-				.maxResults(pageSize)
-				.build();
+			int totalDeleted = 0;
+			String nextToken = null;
 
-			var events = client.listEvents(listEventsRequest).events();
+			do {
+				var requestBuilder = ListEventsRequest.builder()
+					.memoryId(memoryId)
+					.actorId(actorAndSession.actor())
+					.sessionId(actorAndSession.session())
+					.includePayloads(false)
+					.maxResults(pageSize);
 
-			events.forEach(event -> client.deleteEvent(DeleteEventRequest.builder()
-				.memoryId(memoryId)
-				.actorId(actorAndSession.actor())
-				.sessionId(actorAndSession.session())
-				.eventId(event.eventId())
-				.build()));
+				if (nextToken != null) {
+					requestBuilder.nextToken(nextToken);
+				}
 
-			logger.debug("Successfully deleted {} events for conversation: {}", events.size(), conversationId);
+				var listEventsResponse = client.listEvents(requestBuilder.build());
+				var events = listEventsResponse.events();
+				nextToken = listEventsResponse.nextToken();
+
+				for (var event : events) {
+					client.deleteEvent(DeleteEventRequest.builder()
+						.memoryId(memoryId)
+						.actorId(actorAndSession.actor())
+						.sessionId(actorAndSession.session())
+						.eventId(event.eventId())
+						.build());
+				}
+				totalDeleted += events.size();
+			}
+			while (nextToken != null);
+
+			logger.debug("Successfully deleted {} events for conversation: {}", totalDeleted, conversationId);
 		}
 		catch (SdkException e) {
 			logger.error("Failed to delete conversation: {}", conversationId, e);


### PR DESCRIPTION
## Summary

`AgentCoreShortTermMemoryRepository.deleteByConversationId()` calls `listEvents` once with `maxResults(pageSize)` but never paginates using `nextToken`. If a conversation has more events than `pageSize`, the remaining events are silently orphaned — never deleted, never visible, wasting storage indefinitely.

## Root Cause

The `fetchAllEvents()` method in the same class correctly implements pagination with a `do/while` loop checking `nextToken`. The `deleteByConversationId()` method was simply missing the same pattern.

## Changes

- **`AgentCoreShortTermMemoryRepository.java`** — Added `do/while` pagination loop with `nextToken` handling in `deleteByConversationId()`, matching the existing `fetchAllEvents()` pattern

## Before vs After

```java
// BEFORE — single page, orphans remaining events
var events = client.listEvents(request).events();
events.forEach(event -> client.deleteEvent(...));

// AFTER — paginates through ALL events
String nextToken = null;
do {
    var response = client.listEvents(requestBuilder.build());
    response.events().forEach(event -> client.deleteEvent(...));
    nextToken = response.nextToken();
} while (nextToken != null);


**Testing**
mvn test -pl spring-ai-agentcore-memory — 94 tests, 0 failures
mvn spring-javaformat:apply — clean

Fixes #[52](https://github.com/spring-ai-community/spring-ai-agentcore/issues/52)