### PR TITLE
fix: Add destroyMethod="close" to BedrockAgentCoreClient beans

### DIFF
--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserAutoConfiguration.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserAutoConfiguration.java
@@ -58,7 +58,7 @@ public class AgentCoreBrowserAutoConfiguration {
 
 	// ========== AgentCore mode beans ==========
 
-	@Bean
+	@Bean(destroyMethod = "close")
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(name = "agentcore.browser.mode", havingValue = "agentcore", matchIfMissing = true)
 	BedrockAgentCoreClient bedrockAgentCoreClient() {

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterAutoConfiguration.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterAutoConfiguration.java
@@ -44,14 +44,14 @@ public class AgentCoreCodeInterpreterAutoConfiguration {
 
 	private static final Logger logger = LoggerFactory.getLogger(AgentCoreCodeInterpreterAutoConfiguration.class);
 
-	@Bean
+	@Bean(destroyMethod = "close")
 	@ConditionalOnMissingBean
 	BedrockAgentCoreClient bedrockAgentCoreClient() {
 		logger.debug("Creating BedrockAgentCoreClient bean");
 		return BedrockAgentCoreClient.create();
 	}
 
-	@Bean
+	@Bean(destroyMethod = "close")
 	@ConditionalOnMissingBean
 	BedrockAgentCoreAsyncClient bedrockAgentCoreAsyncClient() {
 		logger.debug("Creating BedrockAgentCoreAsyncClient bean");

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/AgentCoreShortTermMemoryRepositoryAutoConfiguration.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/AgentCoreShortTermMemoryRepositoryAutoConfiguration.java
@@ -35,7 +35,7 @@ public class AgentCoreShortTermMemoryRepositoryAutoConfiguration {
 	private static final Logger logger = LoggerFactory
 		.getLogger(AgentCoreShortTermMemoryRepositoryAutoConfiguration.class);
 
-	@Bean
+	@Bean(destroyMethod = "close")
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(prefix = AgentCoreMemoryProperties.CONFIG_PREFIX, name = "memory-id")
 	BedrockAgentCoreClient bedrockAgentCoreClient() {


### PR DESCRIPTION
**Summary**
BedrockAgentCoreClient and BedrockAgentCoreAsyncClient beans are registered with @Bean but without destroyMethod = "close" in three auto-configuration classes. These AWS SDK clients hold HTTP connection pools, thread pools, and socket connections that are never cleaned up on application shutdown.

**Root Cause**
The browser module's Playwright bean already correctly uses @Bean(destroyMethod = "close"), but the SDK client beans across three modules missed it.

**Changes**
File	Change
```
AgentCoreCodeInterpreterAutoConfiguration.java	destroyMethod = "close" on sync + async client beans
AgentCoreBrowserAutoConfiguration.java	destroyMethod = "close" on sync client bean
AgentCoreShortTermMemoryRepositoryAutoConfiguration.java	destroyMethod = "close" on sync client bean
Before vs After
// BEFORE — connection pool and threads leak on shutdown
@Bean
@ConditionalOnMissingBean
BedrockAgentCoreClient bedrockAgentCoreClient() { ... }

// AFTER — Spring calls close() on shutdown
@Bean(destroyMethod = "close")
@ConditionalOnMissingBean
BedrockAgentCoreClient bedrockAgentCoreClient() { ... }
```
**Impact Without Fix**
On every app shutdown/restart, HTTP connection pool threads and sockets are not released
In containerized environments (ECS, Kubernetes) with frequent rolling deploys: thread count creep, "too many open files" errors, slower shutdown times

**Testing**
mvn test -pl spring-ai-agentcore-code-interpreter,spring-ai-agentcore-browser,spring-ai-agentcore-memory — all tests pass, 0 failures
mvn spring-javaformat:apply — clean

Fixes #53

