### PR TITLE
Add custom User-Agent header via SDK USER_AGENT_APP_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ An open-source library that brings Amazon Bedrock AgentCore capabilities into Sp
 | [Browser](spring-ai-agentcore-browser/) | Web navigation, content extraction, screenshots, form interaction via Playwright |
 | [Code Interpreter](spring-ai-agentcore-code-interpreter/) | Secure Python/JavaScript/TypeScript execution with file retrieval |
 | [Artifact Store](spring-ai-agentcore-artifact-store/) | Session-scoped, TTL-based storage for generated files |
+| [Common](spring-ai-agentcore-common/) | Shared utilities — automatic User-Agent tagging for AWS SDK clients |
 | [BOM](spring-ai-agentcore-bom/) | Bill of Materials for version alignment |
 
 ## Quick Start

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <url>https://github.com/spring-ai-community/spring-ai-agentcore</url>
     <modules>
         <module>spring-ai-agentcore-bom</module>
+        <module>spring-ai-agentcore-common</module>
         <module>spring-ai-agentcore-artifact-store</module>
         <module>spring-ai-agentcore-runtime-starter</module>
         <module>spring-ai-agentcore-memory</module>

--- a/spring-ai-agentcore-bom/pom.xml
+++ b/spring-ai-agentcore-bom/pom.xml
@@ -59,6 +59,11 @@
         <dependencies>
             <dependency>
                 <groupId>org.springaicommunity</groupId>
+                <artifactId>spring-ai-agentcore-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springaicommunity</groupId>
                 <artifactId>spring-ai-agentcore-artifact-store</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/spring-ai-agentcore-browser/pom.xml
+++ b/spring-ai-agentcore-browser/pom.xml
@@ -69,6 +69,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-agentcore-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>bedrockagentcore</artifactId>
         </dependency>

--- a/spring-ai-agentcore-code-interpreter/pom.xml
+++ b/spring-ai-agentcore-code-interpreter/pom.xml
@@ -69,6 +69,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-agentcore-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>bedrockagentcore</artifactId>
         </dependency>

--- a/spring-ai-agentcore-common/README.md
+++ b/spring-ai-agentcore-common/README.md
@@ -1,0 +1,18 @@
+# Spring AI AgentCore Common
+
+Shared utilities for Spring AI AgentCore modules. Automatically tags all AWS SDK clients with a `spring-ai-agentcore/<version>` User-Agent identifier via the `sdk.ua.appId` system property.
+
+## How It Works
+
+`AgentCoreUserAgentInterceptor` is registered as an AWS SDK `ExecutionInterceptor` through the Java service loader. When any SDK client is created, the interceptor's static initializer calls `UserAgentProvider.configure()`, which sets (or appends to) the `sdk.ua.appId` system property. No application code or configuration is required — adding this module as a dependency is sufficient.
+
+## Key Classes
+
+| Class | Purpose |
+|-------|---------|
+| `UserAgentProvider` | Sets the `sdk.ua.appId` system property; appends to any existing value; idempotent |
+| `AgentCoreUserAgentInterceptor` | SDK `ExecutionInterceptor` auto-loaded via service loader |
+
+## License
+
+Apache License 2.0

--- a/spring-ai-agentcore-common/pom.xml
+++ b/spring-ai-agentcore-common/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springaicommunity</groupId>
+        <artifactId>spring-ai-agentcore-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <url>https://github.com/spring-ai-community/spring-ai-agentcore</url>
+    <scm>
+        <url>https://github.com/spring-ai-community/spring-ai-agentcore</url>
+        <connection>git://github.com/spring-ai-community/spring-ai-agentcore.git</connection>
+        <developerConnection>git@github.com/spring-ai-community/spring-ai-agentcore.git</developerConnection>
+    </scm>
+
+    <artifactId>spring-ai-agentcore-common</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Spring AI AgentCore Common</name>
+    <description>Shared utilities for Spring AI AgentCore modules</description>
+
+    <organization>
+        <name>Spring AI Community</name>
+        <url>https://github.com/spring-ai-community</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>Apache License</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Yuriy Bezsonov</name>
+            <email>ybezsonov@gmail.com</email>
+        </developer>
+    </developers>
+
+    <issueManagement>
+        <system>Github Issues</system>
+        <url>https://github.com/spring-ai-community/spring-ai-agentcore/issues</url>
+    </issueManagement>
+    <ciManagement>
+        <system>Github Actions</system>
+        <url>https://github.com/spring-ai-community/spring-ai-agentcore/actions</url>
+    </ciManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
+</project>

--- a/spring-ai-agentcore-common/pom.xml
+++ b/spring-ai-agentcore-common/pom.xml
@@ -37,8 +37,8 @@
 
     <developers>
         <developer>
-            <name>Yuriy Bezsonov</name>
-            <email>ybezsonov@gmail.com</email>
+            <name>Matthew Meckes</name>
+            <email>matt.meckes@gmail.com</email>
         </developer>
     </developers>
 

--- a/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/AgentCoreUserAgentInterceptor.java
+++ b/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/AgentCoreUserAgentInterceptor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.common;
+
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+
+/**
+ * Global interceptor auto-loaded by the AWS SDK via service loader. Configures the
+ * User-Agent app ID in its static initializer so every SDK client picks it up.
+ *
+ * @author Yuriy Bezsonov
+ */
+public final class AgentCoreUserAgentInterceptor implements ExecutionInterceptor {
+
+	static {
+		UserAgentProvider.configure();
+	}
+
+	@Override
+	public SdkRequest modifyRequest(Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
+		return context.request();
+	}
+
+}

--- a/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/AgentCoreUserAgentInterceptor.java
+++ b/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/AgentCoreUserAgentInterceptor.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
  * Global interceptor auto-loaded by the AWS SDK via service loader. Configures the
  * User-Agent app ID in its static initializer so every SDK client picks it up.
  *
- * @author Yuriy Bezsonov
+ * @author Matt Meckes
  */
 public final class AgentCoreUserAgentInterceptor implements ExecutionInterceptor {
 

--- a/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/UserAgentProvider.java
+++ b/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/UserAgentProvider.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * automatically include the spring-ai-agentcore identifier in the User-Agent header.
  * Preserves any user-provided value by appending rather than replacing.
  *
- * @author Yuriy Bezsonov
+ * @author Matt Meckes
  */
 public final class UserAgentProvider {
 

--- a/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/UserAgentProvider.java
+++ b/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/UserAgentProvider.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.common;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configures the AWS SDK {@code sdk.ua.appId} system property so that all SDK clients
+ * automatically include the spring-ai-agentcore identifier in the User-Agent header.
+ * Preserves any user-provided value by appending rather than replacing.
+ *
+ * @author Yuriy Bezsonov
+ */
+public final class UserAgentProvider {
+
+	private static final Logger logger = LoggerFactory.getLogger(UserAgentProvider.class);
+
+	private static final String SDK_USER_AGENT_APP_ID = "sdk.ua.appId";
+
+	private static final String APP_ID;
+
+	static {
+		String version = "unknown";
+		try (InputStream is = UserAgentProvider.class.getResourceAsStream("/version.properties")) {
+			if (is != null) {
+				Properties props = new Properties();
+				props.load(is);
+				version = props.getProperty("version", "unknown");
+			}
+		}
+		catch (IOException ex) {
+			logger.warn("Failed to load version.properties", ex);
+		}
+		APP_ID = "spring-ai-agentcore/" + version;
+	}
+
+	private UserAgentProvider() {
+	}
+
+	/**
+	 * Sets the {@code sdk.ua.appId} system property, appending to any existing
+	 * user-provided value. Safe to call multiple times; subsequent calls are no-ops if
+	 * the value already contains the spring-ai-agentcore identifier.
+	 */
+	public static void configure() {
+		try {
+			String existing = System.getProperty(SDK_USER_AGENT_APP_ID);
+			if (existing != null && existing.contains(APP_ID)) {
+				return;
+			}
+			String newValue = (existing == null || existing.isEmpty()) ? APP_ID : existing + "/" + APP_ID;
+			System.setProperty(SDK_USER_AGENT_APP_ID, newValue);
+			logger.debug("Set {} = {}", SDK_USER_AGENT_APP_ID, newValue);
+		}
+		catch (Exception ex) {
+			logger.warn("Unable to configure user agent system property", ex);
+		}
+	}
+
+	public static String appId() {
+		return APP_ID;
+	}
+
+}

--- a/spring-ai-agentcore-common/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
+++ b/spring-ai-agentcore-common/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
@@ -1,0 +1,1 @@
+org.springaicommunity.agentcore.common.AgentCoreUserAgentInterceptor

--- a/spring-ai-agentcore-common/src/main/resources/version.properties
+++ b/spring-ai-agentcore-common/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/spring-ai-agentcore-common/src/test/java/org/springaicommunity/agentcore/common/UserAgentProviderTest.java
+++ b/spring-ai-agentcore-common/src/test/java/org/springaicommunity/agentcore/common/UserAgentProviderTest.java
@@ -16,15 +16,20 @@
 
 package org.springaicommunity.agentcore.common;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UserAgentProviderTest {
 
+	@AfterEach
+	void resetSystemProperty() {
+		System.clearProperty("sdk.ua.appId");
+	}
+
 	@Test
 	void configureSetsSystemProperty() {
-		System.clearProperty("sdk.ua.appId");
 		UserAgentProvider.configure();
 		assertThat(System.getProperty("sdk.ua.appId")).startsWith("spring-ai-agentcore/");
 	}

--- a/spring-ai-agentcore-common/src/test/java/org/springaicommunity/agentcore/common/UserAgentProviderTest.java
+++ b/spring-ai-agentcore-common/src/test/java/org/springaicommunity/agentcore/common/UserAgentProviderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserAgentProviderTest {
+
+	@Test
+	void configureSetsSystemProperty() {
+		System.clearProperty("sdk.ua.appId");
+		UserAgentProvider.configure();
+		assertThat(System.getProperty("sdk.ua.appId")).startsWith("spring-ai-agentcore/");
+	}
+
+	@Test
+	void configureAppendsToExistingValue() {
+		System.setProperty("sdk.ua.appId", "my-app");
+		UserAgentProvider.configure();
+		String value = System.getProperty("sdk.ua.appId");
+		assertThat(value).startsWith("my-app/");
+		assertThat(value).contains("spring-ai-agentcore/");
+	}
+
+	@Test
+	void configureIsIdempotent() {
+		System.clearProperty("sdk.ua.appId");
+		UserAgentProvider.configure();
+		String first = System.getProperty("sdk.ua.appId");
+		UserAgentProvider.configure();
+		assertThat(System.getProperty("sdk.ua.appId")).isEqualTo(first);
+	}
+
+	@Test
+	void appIdStartsWithExpectedPrefix() {
+		assertThat(UserAgentProvider.appId()).startsWith("spring-ai-agentcore/");
+	}
+
+}

--- a/spring-ai-agentcore-memory/pom.xml
+++ b/spring-ai-agentcore-memory/pom.xml
@@ -73,6 +73,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-agentcore-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>bedrockagentcore</artifactId>
         </dependency>


### PR DESCRIPTION
Sets the `sdk.ua.appId` system property using an `ExecutionInterceptor` auto-loaded via service loader (following the Powertools for AWS Lambda pattern).

This approach:
- Works globally for all SDK clients, including user-configured custom ones
- Appends to any existing user-provided app ID rather than overwriting
- Requires no per-module wiring — the service loader handles registration automatically

Supersedes #62.