### PR TITLE
Simplify examples build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,17 @@ jobs:
           distribution: 'corretto'
       - name: Build with Maven
         run: mvn -ntp clean verify
+
+  examples:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'corretto'
+      - name: Install library modules
+        run: mvn -ntp clean install -DskipTests
+      - name: Build and test examples
+        run: mvn -ntp clean verify -f examples/pom.xml

--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ mvn test                       # Unit tests
 mvn spring-javaformat:apply    # Format (required before commit)
 ```
 
+### Building the examples
+
+The [`examples/`](examples/) tree is a separate multi-module Maven build that depends on
+the AgentCore modules. Run `mvn -DskipTests install` at the repo root first so the
+examples can resolve the `1.1.0-SNAPSHOT` artifacts locally, then:
+
+```bash
+mvn clean verify -f examples/pom.xml
+```
+
 Each module also has an [AGENTS.md](AGENTS.md) file providing context for AI coding assistants (project structure, conventions, key classes).
 
 ## License

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,6 @@
     <properties>
         <java.version>21</java.version>
         <spring-ai.version>1.1.2</spring-ai.version>
-        <spring-ai-agentcore.version>1.1.0-SNAPSHOT</spring-ai-agentcore.version>
     </properties>
 
     <modules>
@@ -34,8 +33,20 @@
         <module>spring-ai-sse-chat-client</module>
     </modules>
 
+    <!--
+        BOMs import managed dependency versions so examples never pin versions directly:
+        - spring-ai-agentcore-bom: all org.springaicommunity agentcore artifacts
+        - spring-ai-bom: Spring AI starters (Bedrock, etc.)
+    -->
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.springaicommunity</groupId>
+                <artifactId>spring-ai-agentcore-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-bom</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.9</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>org.springaicommunity.examples</groupId>
+    <artifactId>spring-ai-agentcore-examples</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Spring AI AgentCore Examples</name>
+
+    <properties>
+        <java.version>21</java.version>
+        <spring-ai.version>1.1.2</spring-ai.version>
+        <spring-ai-agentcore.version>1.1.0-SNAPSHOT</spring-ai-agentcore.version>
+    </properties>
+
+    <modules>
+        <module>simple-spring-boot-app</module>
+        <module>spring-ai-browser</module>
+        <module>spring-ai-extended-chat-client</module>
+        <module>spring-ai-memory-integration</module>
+        <module>spring-ai-override-invocations</module>
+        <module>spring-ai-simple-chat-client</module>
+        <module>spring-ai-sse-chat-client</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/examples/simple-spring-boot-app/Dockerfile
+++ b/examples/simple-spring-boot-app/Dockerfile
@@ -1,22 +1,9 @@
 FROM --platform=linux/arm64 amazoncorretto:21-alpine
 
-# Create non-root user
 RUN addgroup -S appuser && adduser -S appuser -G appuser
-
-# Set working directory
 WORKDIR /app
-
-# Copy JAR file
-COPY target/simple-agent-app-1.0.0-SNAPSHOT.jar app.jar
-
-# Change ownership to non-root user
+COPY target/simple-spring-boot-app.jar app.jar
 RUN chown appuser:appuser /app/app.jar
-
-# Switch to non-root user
 USER appuser
-
-# Expose port
 EXPOSE 8080
-
-# Use exec form (container support is default in JDK 21)
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/examples/simple-spring-boot-app/pom.xml
+++ b/examples/simple-spring-boot-app/pom.xml
@@ -4,37 +4,29 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.example</groupId>
-    <artifactId>simple-agent-app</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <parent>
+        <groupId>org.springaicommunity.examples</groupId>
+        <artifactId>spring-ai-agentcore-examples</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
 
+    <artifactId>simple-spring-boot-app</artifactId>
     <name>Simple Agent App</name>
     <description>Example Spring Boot application using AgentCore starter</description>
-
-    <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
-        <spring.boot.version>3.2.0</spring.boot.version>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>${spring.boot.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>${spring.boot.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-runtime-starter</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>${spring-ai-agentcore.version}</version>
         </dependency>
     </dependencies>
 
@@ -43,14 +35,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/examples/simple-spring-boot-app/pom.xml
+++ b/examples/simple-spring-boot-app/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-runtime-starter</artifactId>
-            <version>${spring-ai-agentcore.version}</version>
         </dependency>
     </dependencies>
 

--- a/examples/spring-ai-browser/pom.xml
+++ b/examples/spring-ai-browser/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-browser</artifactId>
-            <version>${spring-ai-agentcore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>

--- a/examples/spring-ai-browser/pom.xml
+++ b/examples/spring-ai-browser/pom.xml
@@ -1,54 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.9</version>
-		<relativePath/>
-	</parent>
-	<groupId>com.unicorn</groupId>
-	<artifactId>browser-example</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
-	<name>browser-example</name>
-	<description>AgentCore Browser example — local by default, switchable to remote</description>
-	<properties>
-		<java.version>17</java.version>
-		<spring-ai.version>1.1.2</spring-ai.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springaicommunity</groupId>
-			<artifactId>spring-ai-agentcore-browser</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-	</dependencies>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.ai</groupId>
-				<artifactId>spring-ai-bom</artifactId>
-				<version>${spring-ai.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springaicommunity.examples</groupId>
+        <artifactId>spring-ai-agentcore-examples</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-ai-browser-example</artifactId>
+    <name>AgentCore Browser Example</name>
+    <description>AgentCore Browser example — local by default, switchable to remote</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-agentcore-browser</artifactId>
+            <version>${spring-ai-agentcore.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/examples/spring-ai-extended-chat-client/Dockerfile
+++ b/examples/spring-ai-extended-chat-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 amazoncorretto:21-alpine
+FROM amazoncorretto:21-alpine
 
 # Create non-root user
 RUN addgroup -S appuser && adduser -S appuser -G appuser
@@ -6,7 +6,7 @@ RUN addgroup -S appuser && adduser -S appuser -G appuser
 WORKDIR /app
 
 # Copy the jar file
-COPY target/spring-ai-extended-chat-client-1.0.0-SNAPSHOT.jar app.jar
+COPY target/spring-ai-extended-chat-client-*.jar app.jar
 
 # Change ownership
 RUN chown appuser:appuser /app/app.jar

--- a/examples/spring-ai-extended-chat-client/Dockerfile
+++ b/examples/spring-ai-extended-chat-client/Dockerfile
@@ -1,21 +1,9 @@
 FROM --platform=linux/arm64 amazoncorretto:21-alpine
 
-# Create non-root user
 RUN addgroup -S appuser && adduser -S appuser -G appuser
-
 WORKDIR /app
-
-# Copy the jar file
 COPY target/spring-ai-extended-chat-client.jar app.jar
-
-# Change ownership
 RUN chown appuser:appuser /app/app.jar
-
-# Switch to non-root user
 USER appuser
-
-# Expose port
 EXPOSE 8080
-
-# Run the application
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/examples/spring-ai-extended-chat-client/Dockerfile
+++ b/examples/spring-ai-extended-chat-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21-alpine
+FROM --platform=linux/arm64 amazoncorretto:21-alpine
 
 # Create non-root user
 RUN addgroup -S appuser && adduser -S appuser -G appuser
@@ -6,7 +6,7 @@ RUN addgroup -S appuser && adduser -S appuser -G appuser
 WORKDIR /app
 
 # Copy the jar file
-COPY target/spring-ai-extended-chat-client-*.jar app.jar
+COPY target/spring-ai-extended-chat-client.jar app.jar
 
 # Change ownership
 RUN chown appuser:appuser /app/app.jar

--- a/examples/spring-ai-extended-chat-client/README.md
+++ b/examples/spring-ai-extended-chat-client/README.md
@@ -32,7 +32,7 @@ Spring AI chat client with OAuth authentication and per-user memory isolation, d
 - AWS CLI configured with appropriate permissions
 - Docker installed and running
 - Terraform >= 1.0
-- Java 17+ and Maven 3.6+
+- Java 21+ and Maven 3.6+
 
 > **Building on non-arm64 hosts**: AgentCore requires `linux/arm64` images. If building on a different architecture, you need an ARM64 emulation layer (e.g. [QEMU](https://github.com/tonistiigi/binfmt)). Docker Desktop includes this by default.
 

--- a/examples/spring-ai-extended-chat-client/README.md
+++ b/examples/spring-ai-extended-chat-client/README.md
@@ -34,6 +34,8 @@ Spring AI chat client with OAuth authentication and per-user memory isolation, d
 - Terraform >= 1.0
 - Java 17+ and Maven 3.6+
 
+> **Building on non-arm64 hosts** (e.g. Intel/AMD Linux or Windows): AgentCore Runtime requires `linux/arm64` images. Register QEMU once per host with `docker run --privileged --rm tonistiigi/binfmt --install arm64`. Docker Desktop already includes this.
+
 ### Deploy
 
 1. **Build and deploy:**

--- a/examples/spring-ai-extended-chat-client/README.md
+++ b/examples/spring-ai-extended-chat-client/README.md
@@ -34,7 +34,7 @@ Spring AI chat client with OAuth authentication and per-user memory isolation, d
 - Terraform >= 1.0
 - Java 17+ and Maven 3.6+
 
-> **Building on non-arm64 hosts** (e.g. Intel/AMD Linux or Windows): AgentCore Runtime requires `linux/arm64` images. Register QEMU once per host with `docker run --privileged --rm tonistiigi/binfmt --install arm64`. Docker Desktop already includes this.
+> **Building on non-arm64 hosts**: AgentCore requires `linux/arm64` images. If building on a different architecture, you need an ARM64 emulation layer (e.g. [QEMU](https://github.com/tonistiigi/binfmt)). Docker Desktop includes this by default.
 
 ### Deploy
 

--- a/examples/spring-ai-extended-chat-client/pom.xml
+++ b/examples/spring-ai-extended-chat-client/pom.xml
@@ -26,12 +26,10 @@
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-memory</artifactId>
-            <version>${spring-ai-agentcore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-runtime-starter</artifactId>
-            <version>${spring-ai-agentcore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>

--- a/examples/spring-ai-extended-chat-client/pom.xml
+++ b/examples/spring-ai-extended-chat-client/pom.xml
@@ -71,6 +71,7 @@
     </dependencies>
 
     <build>
+        <finalName>spring-ai-extended-chat-client</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/examples/spring-ai-extended-chat-client/pom.xml
+++ b/examples/spring-ai-extended-chat-client/pom.xml
@@ -5,24 +5,16 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
-        <relativePath/>
+        <groupId>org.springaicommunity.examples</groupId>
+        <artifactId>spring-ai-agentcore-examples</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.springaicommunity.examples</groupId>
     <artifactId>spring-ai-extended-chat-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
     <name>Spring AI Extended Chat Client</name>
     <description>Spring AI chat client deployable into AgentCore and uses authentication context with short-term memory</description>
 
     <properties>
-        <java.version>17</java.version>
-        <spring-ai.version>1.1.1</spring-ai.version>
-        <awssdk.version>2.40.3</awssdk.version>
         <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
     </properties>
 
@@ -31,38 +23,29 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-memory</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>${spring-ai-agentcore.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-runtime-starter</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>${spring-ai-agentcore.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
-            <version>${spring-ai.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-model</artifactId>
-            <version>${spring-ai.version}</version>
         </dependency>
-
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>${nimbus-jose-jwt.version}</version>
         </dependency>
-
-        <!-- Test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -71,7 +54,6 @@
     </dependencies>
 
     <build>
-        <finalName>spring-ai-extended-chat-client</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/examples/spring-ai-memory-integration/pom.xml
+++ b/examples/spring-ai-memory-integration/pom.xml
@@ -5,54 +5,37 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.9</version>
-        <relativePath/>
+        <groupId>org.springaicommunity.examples</groupId>
+        <artifactId>spring-ai-agentcore-examples</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.springaicommunity.examples</groupId>
     <artifactId>spring-ai-memory-integration</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
     <name>Spring AI Memory Integration Example</name>
     <description>Example showing how to integrate AgentCore Memory into existing Spring Boot applications</description>
-
-    <properties>
-        <java.version>17</java.version>
-        <spring-ai.version>1.1.2</spring-ai.version>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-memory</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>${spring-ai-agentcore.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
-            <version>${spring-ai.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-model</artifactId>
-            <version>${spring-ai.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>

--- a/examples/spring-ai-memory-integration/pom.xml
+++ b/examples/spring-ai-memory-integration/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-memory</artifactId>
-            <version>${spring-ai-agentcore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>

--- a/examples/spring-ai-override-invocations/Dockerfile
+++ b/examples/spring-ai-override-invocations/Dockerfile
@@ -1,22 +1,9 @@
 FROM --platform=linux/arm64 amazoncorretto:21-alpine
 
-# Create non-root user
 RUN addgroup -S appuser && adduser -S appuser -G appuser
-
-# Set working directory
 WORKDIR /app
-
-# Copy JAR file
-COPY target/sse-agents-0.0.1-SNAPSHOT.jar app.jar
-
-# Change ownership to non-root user
+COPY target/spring-ai-override-invocations.jar app.jar
 RUN chown appuser:appuser /app/app.jar
-
-# Switch to non-root user
 USER appuser
-
-# Expose port
 EXPOSE 8080
-
-# Use exec form (container support is default in JDK 21)
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/examples/spring-ai-override-invocations/pom.xml
+++ b/examples/spring-ai-override-invocations/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-runtime-starter</artifactId>
-            <version>${spring-ai-agentcore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-ai-override-invocations/pom.xml
+++ b/examples/spring-ai-override-invocations/pom.xml
@@ -1,69 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.unicorn</groupId>
-	<artifactId>spring-ai-override-invocations</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
-	<name>spring-ai-override-invocations</name>
-	<description>Spring AI AgentCore Controller Override Example</description>
-	<properties>
-		<java.version>21</java.version>
-		<spring-ai.version>1.0.0</spring-ai.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
-		</dependency>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.springaicommunity.examples</groupId>
+        <artifactId>spring-ai-agentcore-examples</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-ai-override-invocations</artifactId>
+    <name>Spring AI AgentCore Controller Override Example</name>
+    <description>Spring AI AgentCore Controller Override Example</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-runtime-starter</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>${spring-ai-agentcore.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.ai</groupId>
-				<artifactId>spring-ai-bom</artifactId>
-				<version>${spring-ai.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-
-	</dependencyManagement>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/examples/spring-ai-simple-chat-client/Dockerfile
+++ b/examples/spring-ai-simple-chat-client/Dockerfile
@@ -1,22 +1,9 @@
 FROM --platform=linux/arm64 amazoncorretto:21-alpine
 
-# Create non-root user
 RUN addgroup -S appuser && adduser -S appuser -G appuser
-
-# Set working directory
 WORKDIR /app
-
-# Copy JAR file
-COPY target/agents-1.0.0-SNAPSHOT.jar app.jar
-
-# Change ownership to non-root user
+COPY target/spring-ai-simple-chat-client.jar app.jar
 RUN chown appuser:appuser /app/app.jar
-
-# Switch to non-root user
 USER appuser
-
-# Expose port
 EXPOSE 8080
-
-# Use exec form (container support is default in JDK 21)
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/examples/spring-ai-simple-chat-client/pom.xml
+++ b/examples/spring-ai-simple-chat-client/pom.xml
@@ -1,70 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.unicorn</groupId>
-	<artifactId>agents</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
-	<name>agents</name>
-	<description>Simple Bedrock Chat Client for Spring AI</description>
-	<properties>
-		<java.version>21</java.version>
-		<spring-ai.version>1.0.0</spring-ai.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
-		</dependency>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.springaicommunity.examples</groupId>
+        <artifactId>spring-ai-agentcore-examples</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-ai-simple-chat-client</artifactId>
+    <name>Simple Bedrock Chat Client for Spring AI</name>
+    <description>Simple Bedrock Chat Client for Spring AI</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-runtime-starter</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>${spring-ai-agentcore.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.ai</groupId>
-				<artifactId>spring-ai-bom</artifactId>
-				<version>${spring-ai.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-
-	</dependencyManagement>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/examples/spring-ai-simple-chat-client/pom.xml
+++ b/examples/spring-ai-simple-chat-client/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-runtime-starter</artifactId>
-            <version>${spring-ai-agentcore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-ai-sse-chat-client/Dockerfile
+++ b/examples/spring-ai-sse-chat-client/Dockerfile
@@ -1,22 +1,9 @@
 FROM --platform=linux/arm64 amazoncorretto:21-alpine
 
-# Create non-root user
 RUN addgroup -S appuser && adduser -S appuser -G appuser
-
-# Set working directory
 WORKDIR /app
-
-# Copy JAR file
-COPY target/sse-agents-1.0.0-SNAPSHOT.jar app.jar
-
-# Change ownership to non-root user
+COPY target/spring-ai-sse-chat-client.jar app.jar
 RUN chown appuser:appuser /app/app.jar
-
-# Switch to non-root user
 USER appuser
-
-# Expose port
 EXPOSE 8080
-
-# Use exec form (container support is default in JDK 21)
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/examples/spring-ai-sse-chat-client/pom.xml
+++ b/examples/spring-ai-sse-chat-client/pom.xml
@@ -1,69 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.unicorn</groupId>
-	<artifactId>sse-agents</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
-	<name>sse-agents</name>
-	<description>SSE Streaming Bedrock Chat Client for Spring AI</description>
-	<properties>
-		<java.version>21</java.version>
-		<spring-ai.version>1.0.0</spring-ai.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
-		</dependency>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.springaicommunity.examples</groupId>
+        <artifactId>spring-ai-agentcore-examples</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-ai-sse-chat-client</artifactId>
+    <name>SSE Streaming Bedrock Chat Client for Spring AI</name>
+    <description>SSE Streaming Bedrock Chat Client for Spring AI</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-runtime-starter</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>${spring-ai-agentcore.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.ai</groupId>
-				<artifactId>spring-ai-bom</artifactId>
-				<version>${spring-ai.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-
-	</dependencyManagement>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/examples/spring-ai-sse-chat-client/pom.xml
+++ b/examples/spring-ai-sse-chat-client/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-runtime-starter</artifactId>
-            <version>${spring-ai-agentcore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Adds a shared parent pom for all 7 examples, replacing inconsistent per-example Spring Boot (3.2–3.5), Spring AI (1.0–1.1.2), and Java  versions with a single source of truth (Spring Boot 3.5.9, Spring AI 1.1.2, Java 21).

- Standardized Dockerfiles with finalName-based jar names
- Added examples CI job that builds and tests all examples on every PR