### PR TITLE
fix: align throttle cache defaults and config-05072026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ hs_err_pid*
 replay_pid*
 
 # IDE
+.cursor/
 .idea/
 *.iws
 *.iml

--- a/spring-ai-agentcore-runtime-starter/README.md
+++ b/spring-ai-agentcore-runtime-starter/README.md
@@ -214,6 +214,9 @@ The starter includes built-in rate limiting using Bucket4j to protect against ex
 # Customize rate limits in requests per minute (optional)
 agentcore.throttle.invocations-limit=50
 agentcore.throttle.ping-limit=200
+# Optional: cap in-memory rate limit buckets (default 100_000) and idle expiry (default 5m)
+agentcore.throttle.max-buckets=100000
+agentcore.throttle.bucket-expiry=5m
 ```
 
 **Rate Limit Response (429):**

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/RateLimitingFilter.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/RateLimitingFilter.java
@@ -54,7 +54,7 @@ public class RateLimitingFilter implements Filter {
 
 	private static final String UTF_8 = "UTF-8";
 
-	private static final long DEFAULT_MAX_BUCKETS = 10_000;
+	private static final long DEFAULT_MAX_BUCKETS = 100_000;
 
 	private static final Duration DEFAULT_BUCKET_EXPIRY = Duration.ofMinutes(5);
 

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/RateLimitingFilter.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/RateLimitingFilter.java
@@ -54,6 +54,13 @@ public class RateLimitingFilter implements Filter {
 
 	private static final String UTF_8 = "UTF-8";
 
+	/**
+	 * Default ceiling on per-client rate limit buckets retained in memory. Raised from
+	 * 10_000 to 100_000 so fleets routing many distinct client IPs (VPC-fronted
+	 * deployments, Kubernetes pods behind an L7 proxy) do not evict legitimate clients
+	 * under normal load. At roughly a few hundred bytes per bucket, steady-state memory
+	 * cost is on the order of tens of MB.
+	 */
 	private static final long DEFAULT_MAX_BUCKETS = 100_000;
 
 	private static final Duration DEFAULT_BUCKET_EXPIRY = Duration.ofMinutes(5);

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/ThrottleConfiguration.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/ThrottleConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springaicommunity.agentcore.throttle;
 
+import java.time.Duration;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -33,10 +35,14 @@ public class ThrottleConfiguration {
 
 	private int pingLimit;
 
+	private long maxBuckets = 100_000L;
+
+	private Duration bucketExpiry = Duration.ofMinutes(5);
+
 	@Bean
 	public FilterRegistrationBean<RateLimitingFilter> rateLimitingFilter() {
 		FilterRegistrationBean<RateLimitingFilter> registrationBean = new FilterRegistrationBean<>();
-		registrationBean.setFilter(new RateLimitingFilter(invocationsLimit, pingLimit));
+		registrationBean.setFilter(new RateLimitingFilter(invocationsLimit, pingLimit, maxBuckets, bucketExpiry));
 		registrationBean.addUrlPatterns(INVOCATIONS_PATH, PING_PATH);
 		registrationBean.setOrder(1);
 		return registrationBean;
@@ -56,6 +62,22 @@ public class ThrottleConfiguration {
 
 	public void setPingLimit(int pingLimit) {
 		this.pingLimit = pingLimit;
+	}
+
+	public long getMaxBuckets() {
+		return maxBuckets;
+	}
+
+	public void setMaxBuckets(long maxBuckets) {
+		this.maxBuckets = maxBuckets;
+	}
+
+	public Duration getBucketExpiry() {
+		return bucketExpiry;
+	}
+
+	public void setBucketExpiry(Duration bucketExpiry) {
+		this.bucketExpiry = bucketExpiry;
 	}
 
 }

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/ThrottleConfigurationBindingTest.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/ThrottleConfigurationBindingTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.throttle;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end wire validation: {@code agentcore.throttle.*} YAML →
+ * {@link ThrottleConfiguration} bean → {@link RateLimitingFilter} constructor argument →
+ * Caffeine {@code maximumSize}.
+ */
+class ThrottleConfigurationBindingTest {
+
+	@Test
+	void bindsDefaultsWhenNothingConfigured() {
+		ThrottleConfiguration cfg = bind(Map.of());
+		assertThat(cfg.getMaxBuckets()).isEqualTo(100_000L);
+		assertThat(cfg.getBucketExpiry()).isEqualTo(Duration.ofMinutes(5));
+	}
+
+	@Test
+	void bindsExplicitMaxBuckets() {
+		ThrottleConfiguration cfg = bind(Map.of("agentcore.throttle.max-buckets", "5000"));
+		assertThat(cfg.getMaxBuckets()).isEqualTo(5_000L);
+	}
+
+	@Test
+	void bindsExplicitBucketExpiry() {
+		ThrottleConfiguration cfg = bind(Map.of("agentcore.throttle.bucket-expiry", "30s"));
+		assertThat(cfg.getBucketExpiry()).isEqualTo(Duration.ofSeconds(30));
+	}
+
+	@Test
+	void bindsAllFourPropertiesTogether() {
+		ThrottleConfiguration cfg = bind(
+				Map.of("agentcore.throttle.invocations-limit", "42", "agentcore.throttle.ping-limit", "99",
+						"agentcore.throttle.max-buckets", "50000", "agentcore.throttle.bucket-expiry", "PT10M"));
+		assertThat(cfg.getInvocationsLimit()).isEqualTo(42);
+		assertThat(cfg.getPingLimit()).isEqualTo(99);
+		assertThat(cfg.getMaxBuckets()).isEqualTo(50_000L);
+		assertThat(cfg.getBucketExpiry()).isEqualTo(Duration.ofMinutes(10));
+	}
+
+	@Test
+	void constructedFilterHonorsBoundConfig() {
+		ThrottleConfiguration cfg = bind(
+				Map.of("agentcore.throttle.invocations-limit", "10", "agentcore.throttle.ping-limit", "10",
+						"agentcore.throttle.max-buckets", "7", "agentcore.throttle.bucket-expiry", "PT1H"));
+		RateLimitingFilter filter = new RateLimitingFilter(cfg.getInvocationsLimit(), cfg.getPingLimit(),
+				cfg.getMaxBuckets(), cfg.getBucketExpiry());
+		assertThat(filter.buckets.policy().eviction().orElseThrow().getMaximum()).isEqualTo(7L);
+	}
+
+	private static ThrottleConfiguration bind(Map<String, String> props) {
+		ConfigurationPropertySource src = new MapConfigurationPropertySource(props);
+		return new Binder(src).bind("agentcore.throttle", ThrottleConfiguration.class)
+			.orElseGet(ThrottleConfiguration::new);
+	}
+
+}


### PR DESCRIPTION
As per discussion -https://github.com/spring-ai-community/spring-ai-agentcore/issues/57 

Raised new PR :

Proposal: expose AgentCore enterprise policies through the starter
Thanks @ybezsonov for the detailed review. Agree on all three points. The URL-string validator is the wrong layer (bypassable via DNS rebinding, redirects, IP encoding), and blocking localhost by default would break local-mode dev loops. Re-scoping this issue toward the gap you identified: the starter does not yet wire enterprisePolicies through to StartBrowserSession.

Scope
Two items, nothing more:

AgentCore mode: add agentcore.browser.enterprise-policies config that maps onto StartBrowserSessionRequest.Builder.enterprisePolicies(Collection<BrowserEnterprisePolicy>). Session-scoped only (RECOMMENDED type). Users who need MANAGED (cannot-override) policies create a custom browser via CreateBrowser and point the starter at it through agentcore.browser.browser-identifier.
Local mode: README section documenting where Chromium reads managed policies from on each OS, plus a sample policy JSON. No code change. On Linux, Chromium reads from the fixed path /etc/chromium/policies/managed/. There is no --policy-dir launch flag, so enforcement is an OS-level install step, not a starter responsibility.
Explicitly out of scope: any Java URL validator, any default policy content, any opinionated blocklist.

Prerequisite: SDK bump
Verified against the AWS SDK jars on Maven Central:

bedrockagentcore 2.40.3 (currently pinned in the parent POM via <awssdk.version>2.40.3</awssdk.version>) does not have BrowserEnterprisePolicy as a class and does not have enterprisePolicies on StartBrowserSessionRequest. Fields present in 2.40.3: traceId, traceParent, browserIdentifier, name, sessionTimeoutSeconds, viewPort, clientToken.
The feature first ships in bedrockagentcore 2.42.17. Latest on Central as of checking is 2.43.2.
New PR needs to bump <awssdk.version> to 2.42.17 at minimum (recommend 2.43.2) and add a small compile-time sanity test that imports BrowserEnterprisePolicy so CI catches any accidental downgrade.

Verified SDK shape (2.43.2)
// from software.amazon.awssdk.services.bedrockagentcore.model
StartBrowserSessionRequest.Builder
    .enterprisePolicies(Collection<BrowserEnterprisePolicy>)
    .enterprisePolicies(BrowserEnterprisePolicy...)
    .enterprisePolicies(Consumer<BrowserEnterprisePolicy.Builder>...)

BrowserEnterprisePolicy.Builder
    .location(ResourceLocation)            // wraps the S3 reference
    .type(String)                          // or .type(BrowserEnterprisePolicyType)

BrowserEnterprisePolicyType: MANAGED | RECOMMENDED   // StartBrowserSession only accepts RECOMMENDED

ResourceLocation.Builder
    .s3(S3Location)

S3Location.Builder
    .bucket(String)
    .prefix(String)       // API field name is 'prefix' (described as "prefix/key")
    .versionId(String)    // optional
Note: the S3 field is named prefix, not key. The AWS API Reference describes it as "prefix/key" but the field name on the wire and in the SDK is prefix.

Configuration surface (proposed)
agentcore:
  browser:
    mode: agentcore
    enterprise-policies:
      - s3:
          bucket: corp-browser-policies
          prefix: policies/production/recommended.json
          # version-id: optional, pinned version
        type: RECOMMENDED
      - s3:
          bucket: corp-browser-policies
          prefix: policies/production/allowlist.json
        type: RECOMMENDED
Maps to nested records on AgentCoreBrowserConfiguration:

public record EnterprisePolicyRef(S3Ref s3, String type) { }
public record S3Ref(String bucket, String prefix, String versionId) { }
Wire-up (the only code change)
Inside AgentCoreBrowserClient.executeInSession, the existing StartBrowserSessionRequest.builder() chain gains a conditional .enterprisePolicies(...):

StartBrowserSessionRequest.Builder requestBuilder = StartBrowserSessionRequest.builder()
    .browserIdentifier(config.browserIdentifier())
    .name(sessionName)
    .sessionTimeoutSeconds(config.sessionTimeoutSeconds())
    .viewPort(ViewPort.builder()
        .width(config.viewportWidth())
        .height(config.viewportHeight())
        .build());

List<BrowserEnterprisePolicy> policies = toSdkPolicies(config.enterprisePolicies());
if (!policies.isEmpty()) {
    requestBuilder.enterprisePolicies(policies);
}

StartBrowserSessionResponse response = client.startBrowserSession(requestBuilder.build());
With the translator:

private static List<BrowserEnterprisePolicy> toSdkPolicies(
        List<AgentCoreBrowserConfiguration.EnterprisePolicyRef> refs) {
    if (refs == null || refs.isEmpty()) {
        return List.of();
    }
    return refs.stream()
        .map(ref -> BrowserEnterprisePolicy.builder()
            .location(ResourceLocation.builder()
                .s3(S3Location.builder()
                    .bucket(ref.s3().bucket())
                    .prefix(ref.s3().prefix())
                    .versionId(ref.s3().versionId())
                    .build())
                .build())
            .type(ref.type())
            .build())
        .toList();
}
BrowserTools, BrowserClient, LocalBrowserClient, and the auto-config need no changes. No public-API break.

References:

[StartBrowserSession API](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_StartBrowserSession.html): enterprisePolicies is an array of BrowserEnterprisePolicy (schema allows up to 100, user guide notes 10 practical limit)
[S3Location](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_S3Location.html): bucket, prefix, versionId
[Browser enterprise policies guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/browser-enterprise-policies.html): .json only, each file up to 5 MB, bucket must be same-region
Tests
Five focused tests:

Binding application.yml into the enterprisePolicies record list
Missing config produces an empty list, not null
Using a mocked BedrockAgentCoreClient, call browseAndExtract with one policy configured and capture the StartBrowserSessionRequest argument. Assert request.enterprisePolicies() has one entry with the expected bucket, prefix, and type
Empty list means request.hasEnterprisePolicies() is false
versionId propagates through to S3Location.versionId
No bypass matrix needed. Chromium enforces URLBlocklist and URLAllowlist after DNS and after redirects, which is where URL-string validation fails.

Example app
New examples/browser-enterprise-policies/:

Working application.yml for AgentCore mode with two policy refs
Sample URLBlocklist plus URLAllowlist policy JSON ready to upload to S3
IAM policy snippet copied from the AWS user guide
Step-by-step README covering both AgentCore and local mode
Sequence
I will close https://github.com/spring-ai-community/spring-ai-agentcore/pull/58.
Bump <awssdk.version> in parent POM from 2.40.3 to 2.43.2 (or at minimum 2.42.17).
Extend AgentCoreBrowserConfiguration with EnterprisePolicyRef and S3Ref records.
Thread policies through AgentCoreBrowserClient.executeInSession.
Five tests.
Example app plus README updates.
Open replacement PR linking to this issue.
I will keeping this issue open as the tracking item. and shortly will give you new PR for review and merge .