### PR TITLE
chore: add CODEOWNERS for automatic reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS — auto-requests review from listed maintainers on every PR.
+# To make their approval *required* (not just requested), enable
+# "Require review from Code Owners" in branch protection on `main`.
+#
+# Syntax: <pattern>  <@user-or-team> ...
+# Last matching pattern wins, so add narrower rules below the default.
+
+* @maschnetwork @ashakirin @ybezsonov @jamesward


### PR DESCRIPTION
## Summary
Adds `.github/CODEOWNERS` mapping all paths to the four project maintainers (@maschnetwork, @ashakirin, @ybezsonov, @jamesward). On any new PR, GitHub will auto-request a review from this list.

## Notes
- This only **requests** review. To make code-owner approval *required*, enable **"Require review from Code Owners"** in branch protection on `main` — that's a repo settings change, out of scope for this PR.
- Replaces the retired Dependabot `reviewers` config (see #78 background).

## Tested
N/A — config-only change; CODEOWNERS validates via GitHub itself once merged.

Closes #78