### PR TITLE
Add Checkstyle, OpenRewrite, and license build tooling

### DIFF
--- a/build-tools/checkstyle/checkstyle.xml
+++ b/build-tools/checkstyle/checkstyle.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+
+    <!-- Inherit the full spring-javaformat checkstyle ruleset. -->
+    <module name="io.spring.javaformat.checkstyle.SpringChecks"/>
+
+    <!-- LineLength must live at the Checker level, not inside TreeWalker
+         (Checkstyle 8.24+). -->
+    <module name="LineLength">
+        <property name="max" value="140"/>
+    </module>
+
+    <!-- Additions on top of Spring: naming, sizing, and bug catchers
+         that aren't part of the Spring config. -->
+    <module name="TreeWalker">
+
+        <!-- Naming conventions -->
+        <module name="TypeName"/>
+        <module name="MethodName"/>
+        <module name="MemberName"/>
+        <module name="LocalVariableName"/>
+        <module name="ParameterName"/>
+        <module name="LambdaParameterName"/>
+        <module name="CatchParameterName"/>
+        <module name="PatternVariableName"/>
+        <module name="RecordComponentName"/>
+
+        <!-- Constant naming: UPPER_SNAKE_CASE, with two universal idioms allowed:
+             - logger / log : the standard SLF4J / Apache Commons Logging field name
+             - serialVersionUID : fixed by java.io.Serializable's contract -->
+        <module name="ConstantName">
+            <property name="format"
+                      value="^(log(ger)?|serialVersionUID|[A-Z][A-Z0-9]*(_[A-Z0-9]+)*)$"/>
+        </module>
+
+        <!-- Sizing -->
+        <module name="MethodLength">
+            <property name="max" value="80"/>
+        </module>
+        <module name="ParameterNumber">
+            <property name="max" value="7"/>
+        </module>
+
+        <!-- Bug catchers -->
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="NoFinalizer"/>
+        <module name="IllegalInstantiation">
+            <property name="classes"
+                      value="java.lang.Boolean,java.lang.Integer,java.lang.Long,java.lang.Float,java.lang.Double,java.lang.Short,java.lang.Byte,java.lang.Character"/>
+        </module>
+
+        <!-- Code organization -->
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="SummaryJavadoc"/>
+        <module name="InvalidJavadocPosition"/>
+
+    </module>
+
+</module>

--- a/build-tools/license/apache-2.0-header.txt
+++ b/build-tools/license/apache-2.0-header.txt
@@ -1,0 +1,13 @@
+Copyright 2025-2026 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/pom.xml
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springaicommunity</groupId>
+        <artifactId>spring-ai-agentcore-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>spring-ai-agentcore-rewrite-recipes</artifactId>
+    <name>Spring AI AgentCore Rewrite Recipes</name>
+    <description>Build-time-only OpenRewrite recipes for enforcing project conventions. Not published as part of the library.</description>
+
+    <properties>
+        <rewrite.version>8.83.0</rewrite.version>
+        <!-- Don't generate javadoc/sources for tooling artifact. -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.source.skip>true</maven.source.skip>
+        <!-- This module IS the rewrite tooling — don't apply rewrite to itself. -->
+        <rewrite.skip>true</rewrite.skip>
+        <!-- And don't run the project's strict Checkstyle config on tooling code. -->
+        <checkstyle.skip>true</checkstyle.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java</artifactId>
+            <version>${rewrite.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-test</artifactId>
+            <version>${rewrite.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-21</artifactId>
+            <version>${rewrite.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- This module is build tooling, not library code: don't deploy. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/InnerTypeLast.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/InnerTypeLast.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+/**
+ * Moves nested type declarations (inner classes/interfaces/enums) to the end of the
+ * enclosing class body, matching Checkstyle's {@code InnerTypeLast} rule as included in
+ * {@code spring-javaformat-checkstyle}.
+ * <p>
+ * Within each class body, the relative order of non-type members (fields, initializers,
+ * constructors, methods) is preserved, and the relative order of nested types among
+ * themselves is preserved. Only the partition is moved.
+ */
+public class InnerTypeLast extends Recipe {
+
+	@Override
+	public String getDisplayName() {
+		return "Move inner types to end of enclosing class";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Reorders class members so that nested type declarations "
+				+ "(class/interface/enum/record) appear after all fields, "
+				+ "initializers, constructors, and methods, matching " + "Checkstyle's InnerTypeLast.";
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return new JavaIsoVisitor<ExecutionContext>() {
+
+			@Override
+			public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+				J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+				List<Statement> statements = cd.getBody().getStatements();
+				if (statements.size() < 2) {
+					return cd;
+				}
+
+				// Partition while preserving relative order within each partition.
+				List<Statement> nonTypes = new ArrayList<>(statements.size());
+				List<Statement> types = new ArrayList<>();
+				int firstTypeIdx = -1;
+				int lastNonTypeIdx = -1;
+				for (int i = 0; i < statements.size(); i++) {
+					Statement s = statements.get(i);
+					if (s instanceof J.ClassDeclaration) {
+						types.add(s);
+						if (firstTypeIdx == -1) {
+							firstTypeIdx = i;
+						}
+					}
+					else {
+						nonTypes.add(s);
+						lastNonTypeIdx = i;
+					}
+				}
+
+				// Already in the right shape: every non-type comes before every type.
+				if (firstTypeIdx == -1 || lastNonTypeIdx == -1 || lastNonTypeIdx < firstTypeIdx) {
+					return cd;
+				}
+
+				List<Statement> reordered = new ArrayList<>(statements.size());
+				reordered.addAll(nonTypes);
+				reordered.addAll(types);
+				return cd.withBody(cd.getBody().withStatements(reordered));
+			}
+
+		};
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/OverloadMethodsDeclarationOrder.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/OverloadMethodsDeclarationOrder.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+/**
+ * Reorders class body members so that overloaded methods (same name) are grouped
+ * together, matching Checkstyle's {@code OverloadMethodsDeclarationOrder} rule.
+ * <p>
+ * Non-method members (fields, constructors, inner classes) are left in place. When
+ * methods with the same name are separated by other methods, the later occurrences are
+ * moved to immediately follow the first occurrence of that name.
+ */
+public class OverloadMethodsDeclarationOrder extends Recipe {
+
+	@Override
+	public String getDisplayName() {
+		return "Group overloaded methods together";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Reorders class members so that overloaded methods (same name) "
+				+ "are adjacent, matching Checkstyle's OverloadMethodsDeclarationOrder.";
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return new JavaIsoVisitor<ExecutionContext>() {
+
+			@Override
+			public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+				J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+				// Skip interfaces — method ordering there is a design choice
+				if (cd.getKind() == J.ClassDeclaration.Kind.Type.Interface) {
+					return cd;
+				}
+				List<Statement> statements = cd.getBody().getStatements();
+				if (statements.size() < 2) {
+					return cd;
+				}
+
+				List<Statement> reordered = this.reorder(statements);
+				if (reordered.equals(statements)) {
+					return cd;
+				}
+				return cd.withBody(cd.getBody().withStatements(reordered));
+			}
+
+			private List<Statement> reorder(List<Statement> statements) {
+				// Track first-seen position of each method name
+				Map<String, Integer> firstSeen = new LinkedHashMap<>();
+				List<Statement> result = new ArrayList<>(statements.size());
+
+				for (Statement stmt : statements) {
+					if (stmt instanceof J.MethodDeclaration md) {
+						String name = md.getSimpleName();
+						if (firstSeen.containsKey(name)) {
+							// Insert after the last method with this name
+							int insertAfter = this.findLastIndexOfName(result, name);
+							result.add(insertAfter + 1, stmt);
+						}
+						else {
+							firstSeen.put(name, result.size());
+							result.add(stmt);
+						}
+					}
+					else {
+						result.add(stmt);
+					}
+				}
+				return result;
+			}
+
+			private int findLastIndexOfName(List<Statement> list, String name) {
+				for (int i = list.size() - 1; i >= 0; i--) {
+					if (list.get(i) instanceof J.MethodDeclaration md && md.getSimpleName().equals(name)) {
+						return i;
+					}
+				}
+				return -1;
+			}
+
+		};
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/SpringCatch.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/SpringCatch.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.RenameVariable;
+import org.openrewrite.java.tree.J;
+
+/**
+ * Renames single-letter catch parameters to {@code ex}, matching
+ * {@code spring-javaformat-checkstyle}'s {@code SpringCatchCheck}.
+ * <p>
+ * Transforms {@code catch (Exception e) { ... e ... }} to {@code catch (Exception ex) {
+ * ... ex ... }}, updating both the parameter declaration and all references inside the
+ * catch block. Field accesses with the same simple name (e.g. {@code obj.e}) are left
+ * alone — the rename uses OpenRewrite's {@link RenameVariable} utility, which honours
+ * type-info to rename only the catch-local.
+ */
+public class SpringCatch extends Recipe {
+
+	private static final String NEW_NAME = "ex";
+
+	@Override
+	public String getDisplayName() {
+		return "Rename single-letter catch parameters to ex";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Single-letter exception variables are flagged by "
+				+ "spring-javaformat-checkstyle's SpringCatchCheck. This recipe "
+				+ "renames such variables (and references to them within the " + "catch block) to 'ex'.";
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return new JavaIsoVisitor<ExecutionContext>() {
+
+			@Override
+			public J.Try.Catch visitCatch(J.Try.Catch aCatch, ExecutionContext ctx) {
+				J.Try.Catch c = super.visitCatch(aCatch, ctx);
+				J.VariableDeclarations param = c.getParameter().getTree();
+				if (param.getVariables().size() != 1) {
+					return c;
+				}
+				J.VariableDeclarations.NamedVariable namedVar = param.getVariables().get(0);
+				if (namedVar.getSimpleName().length() != 1) {
+					return c;
+				}
+				this.doAfterVisit(new RenameVariable<>(namedVar, NEW_NAME));
+				return c;
+			}
+
+		};
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/SpringImportOrder.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/SpringImportOrder.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+
+/**
+ * Reorders imports to match {@code spring-javaformat-checkstyle}'s
+ * {@code SpringImportOrderCheck}.
+ * <p>
+ * Group order:
+ * <ol>
+ * <li>{@code java.*}</li>
+ * <li>{@code javax.*}</li>
+ * <li>everything else (alphabetical)</li>
+ * <li>{@code org.springframework.*} (alphabetical)</li>
+ * <li>static imports (alphabetical, all together)</li>
+ * </ol>
+ * Each non-empty group is separated from the next by a blank line.
+ * <p>
+ * This recipe is needed because OpenRewrite's bundled {@code OrderImports} recipe and
+ * {@code SpringFormat} style get overridden by an autodetection layout that places
+ * project-prefixed imports in their own group, producing output that does not match
+ * Spring's conventions.
+ */
+public class SpringImportOrder extends Recipe {
+
+	private static final String JAVA_PREFIX = "java.";
+
+	private static final String JAVAX_PREFIX = "javax.";
+
+	private static final String SPRING_PREFIX = "org.springframework.";
+
+	@Override
+	public String getDisplayName() {
+		return "Order imports per Spring convention";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Reorders imports to match spring-javaformat-checkstyle's "
+				+ "SpringImportOrderCheck: java -> javax -> other -> org.springframework -> static, "
+				+ "alphabetical within each group, blank line between groups.";
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return new JavaIsoVisitor<ExecutionContext>() {
+
+			@Override
+			public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+				List<J.Import> originals = cu.getImports();
+				if (originals.size() < 2) {
+					return cu;
+				}
+
+				List<J.Import> javaGroup = new ArrayList<>();
+				List<J.Import> javaxGroup = new ArrayList<>();
+				List<J.Import> otherGroup = new ArrayList<>();
+				List<J.Import> springGroup = new ArrayList<>();
+				List<J.Import> staticGroup = new ArrayList<>();
+
+				for (J.Import imp : originals) {
+					String fqn = imp.getQualid().toString();
+					if (imp.isStatic()) {
+						staticGroup.add(imp);
+					}
+					else if (fqn.startsWith(JAVA_PREFIX)) {
+						javaGroup.add(imp);
+					}
+					else if (fqn.startsWith(JAVAX_PREFIX)) {
+						javaxGroup.add(imp);
+					}
+					else if (fqn.startsWith(SPRING_PREFIX)) {
+						springGroup.add(imp);
+					}
+					else {
+						otherGroup.add(imp);
+					}
+				}
+
+				Comparator<J.Import> byName = Comparator.comparing((imp) -> imp.getQualid().toString());
+				javaGroup.sort(byName);
+				javaxGroup.sort(byName);
+				otherGroup.sort(byName);
+				springGroup.sort(byName);
+				staticGroup.sort(byName);
+
+				List<J.Import> reordered = new ArrayList<>(originals.size());
+				this.appendGroup(reordered, javaGroup, originals.get(0).getPrefix());
+				this.appendGroup(reordered, javaxGroup, null);
+				this.appendGroup(reordered, otherGroup, null);
+				this.appendGroup(reordered, springGroup, null);
+				this.appendGroup(reordered, staticGroup, null);
+
+				// J.Import equality is id-based and ignores prefixes, so reordered
+				// could compare equal to originals even when only blank-line
+				// spacing differs. Rely on cu.withImports() for content-aware
+				// no-op detection instead of an early-return shortcut.
+				return cu.withImports(reordered);
+			}
+
+			/**
+			 * Appends the contents of {@code group} to {@code accumulator}, applying the
+			 * appropriate prefix:
+			 * <ul>
+			 * <li>The very first import in the file keeps its original prefix
+			 * ({@code firstFilePrefix})</li>
+			 * <li>The first import of any subsequent group gets a blank-line prefix
+			 * ({@code "\n\n"})</li>
+			 * <li>Other imports get a single newline prefix</li>
+			 * </ul>
+			 */
+			private void appendGroup(List<J.Import> accumulator, List<J.Import> group, Space firstFilePrefix) {
+				if (group.isEmpty()) {
+					return;
+				}
+				for (int i = 0; i < group.size(); i++) {
+					J.Import imp = group.get(i);
+					Space prefix;
+					if (accumulator.isEmpty() && firstFilePrefix != null) {
+						prefix = firstFilePrefix;
+					}
+					else if (i == 0) {
+						prefix = Space.format("\n\n");
+					}
+					else {
+						prefix = Space.format("\n");
+					}
+					accumulator.add(imp.withPrefix(prefix));
+				}
+			}
+
+		};
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/SpringLambda.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/SpringLambda.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+
+/**
+ * Adds parentheses around single-argument lambda parameter lists, matching
+ * {@code spring-javaformat-checkstyle}'s {@code SpringLambdaCheck}.
+ * <p>
+ * Transforms {@code arg -> body} to {@code (arg) -> body}. Lambdas that already have
+ * parentheses, or that have zero or multiple parameters (which always require
+ * parentheses), are left untouched.
+ */
+public class SpringLambda extends Recipe {
+
+	@Override
+	public String getDisplayName() {
+		return "Add parentheses around single-argument lambdas";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Wraps the parameter of a single-argument lambda in parentheses, "
+				+ "matching spring-javaformat-checkstyle's SpringLambdaCheck.";
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return new JavaIsoVisitor<ExecutionContext>() {
+
+			@Override
+			public J.Lambda visitLambda(J.Lambda lambda, ExecutionContext ctx) {
+				J.Lambda l = super.visitLambda(lambda, ctx);
+				J.Lambda.Parameters params = l.getParameters();
+				if (params.isParenthesized() || params.getParameters().size() != 1) {
+					return l;
+				}
+				return l.withParameters(params.withParenthesized(true));
+			}
+
+		};
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/SpringMethodVisibility.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/SpringMethodVisibility.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.Modifier;
+import org.openrewrite.java.tree.Space;
+
+/**
+ * Removes the {@code public} modifier from methods declared in non-public classes,
+ * matching Spring's {@code SpringMethodVisibility} Checkstyle rule. Methods annotated
+ * with {@code @Override} are left untouched.
+ */
+public class SpringMethodVisibility extends Recipe {
+
+	@Override
+	public String getDisplayName() {
+		return "Remove public from methods in non-public classes";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Removes the public modifier from methods in non-public enclosing classes, "
+				+ "matching Spring's SpringMethodVisibility Checkstyle rule. " + "Methods with @Override are skipped.";
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return new JavaIsoVisitor<ExecutionContext>() {
+
+			@Override
+			public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+				J.MethodDeclaration md = super.visitMethodDeclaration(method, ctx);
+
+				// Only act on public methods
+				if (!this.hasPublicModifier(md)) {
+					return md;
+				}
+
+				// Skip @Override methods
+				if (this.hasOverrideAnnotation(md)) {
+					return md;
+				}
+
+				// Check if enclosing class is non-public
+				Object parent = this.getCursor().getParentTreeCursor().getValue();
+				if (parent instanceof J.Block) {
+					Object grandparent = this.getCursor().getParentTreeCursor().getParentTreeCursor().getValue();
+					if (grandparent instanceof J.ClassDeclaration enclosingClass) {
+						if (this.isNonPublicClass(enclosingClass)) {
+							return this.removePublicModifier(md);
+						}
+					}
+				}
+
+				return md;
+			}
+
+			private boolean hasPublicModifier(J.MethodDeclaration md) {
+				return md.getModifiers().stream().anyMatch((m) -> m.getType() == Modifier.Type.Public);
+			}
+
+			private boolean isNonPublicClass(J.ClassDeclaration cd) {
+				// Skip if enclosing class is public or protected
+				boolean hasPublic = cd.getModifiers().stream().anyMatch((m) -> m.getType() == Modifier.Type.Public);
+				boolean hasProtected = cd.getModifiers()
+					.stream()
+					.anyMatch((m) -> m.getType() == Modifier.Type.Protected);
+				if (hasPublic || hasProtected) {
+					return false;
+				}
+				// Skip if any ancestor is an interface (all interface members
+				// are implicitly public)
+				var cursor = this.getCursor().getParentTreeCursor();
+				while (cursor != null) {
+					Object val = cursor.getValue();
+					if (val instanceof J.ClassDeclaration ancestor) {
+						if (ancestor.getKind() == J.ClassDeclaration.Kind.Type.Interface) {
+							return false;
+						}
+					}
+					var parentCursor = cursor.getParent();
+					if (parentCursor == null) {
+						break;
+					}
+					cursor = parentCursor;
+				}
+				return true;
+			}
+
+			private boolean hasOverrideAnnotation(J.MethodDeclaration md) {
+				return md.getLeadingAnnotations().stream().anyMatch((a) -> "Override".equals(a.getSimpleName()));
+			}
+
+			private J.MethodDeclaration removePublicModifier(J.MethodDeclaration md) {
+				List<Modifier> modifiers = new ArrayList<>(md.getModifiers());
+				Space publicPrefix = modifiers.stream()
+					.filter((m) -> m.getType() == Modifier.Type.Public)
+					.findFirst()
+					.map(Modifier::getPrefix)
+					.orElse(Space.EMPTY);
+				modifiers.removeIf((m) -> m.getType() == Modifier.Type.Public);
+				if (!modifiers.isEmpty()) {
+					// Transfer public's prefix to the next modifier
+					Modifier first = modifiers.get(0);
+					modifiers.set(0, first.withPrefix(publicPrefix));
+					return md.withModifiers(modifiers);
+				}
+				// No modifiers left: transfer prefix to the return type
+				return md.withModifiers(modifiers)
+					.withReturnTypeExpression(md.getReturnTypeExpression().withPrefix(publicPrefix));
+			}
+
+		};
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/SpringTernary.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/main/java/org/springaicommunity/agentcore/rewrite/SpringTernary.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+/**
+ * Rewrites ternary expressions to match {@code spring-javaformat-checkstyle}'s
+ * {@code SpringTernaryCheck}:
+ * <ul>
+ * <li>Wraps the condition in parentheses if not already parenthesized.</li>
+ * <li>Converts {@code (a == b) ? x : y} to {@code (a != b) ? y : x} (uses {@code !=} as
+ * the test, swapping branches accordingly).</li>
+ * </ul>
+ */
+public class SpringTernary extends Recipe {
+
+	@Override
+	public String getDisplayName() {
+		return "Use Spring-style ternary expressions";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Wraps ternary conditions in parentheses and converts == "
+				+ "tests to != with swapped branches, matching " + "spring-javaformat-checkstyle's SpringTernaryCheck.";
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return new JavaIsoVisitor<ExecutionContext>() {
+
+			@Override
+			public J.Ternary visitTernary(J.Ternary ternary, ExecutionContext ctx) {
+				J.Ternary t = super.visitTernary(ternary, ctx);
+				Expression condition = t.getCondition();
+				Expression truePart = t.getTruePart();
+				Expression falsePart = t.getFalsePart();
+
+				// Step 1: flip == to != and swap branches.
+				if (condition instanceof J.Binary binary && binary.getOperator() == J.Binary.Type.Equal) {
+					condition = binary.withOperator(J.Binary.Type.NotEqual);
+					Expression tmp = truePart;
+					truePart = falsePart;
+					falsePart = tmp;
+				}
+
+				// Step 2: wrap condition in parens if not already.
+				if (!(condition instanceof J.Parentheses<?>)) {
+					condition = this.parenthesize(condition);
+				}
+
+				if (condition == t.getCondition() && truePart == t.getTruePart() && falsePart == t.getFalsePart()) {
+					return t;
+				}
+				return t.withCondition(condition).withTruePart(truePart).withFalsePart(falsePart);
+			}
+
+			private J.Parentheses<Expression> parenthesize(Expression expr) {
+				return new J.Parentheses<>(Tree.randomId(), expr.getPrefix(), Markers.EMPTY,
+						new JRightPadded<>(expr.withPrefix(Space.EMPTY), Space.EMPTY, Markers.EMPTY));
+			}
+
+		};
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/InnerTypeLastTests.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/InnerTypeLastTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class InnerTypeLastTests implements RewriteTest {
+
+	@Override
+	public void defaults(RecipeSpec spec) {
+		spec.recipe(new InnerTypeLast());
+	}
+
+	@Test
+	void movesInnerClassAfterMethodWhenItPrecedesAMethod() {
+		this.rewriteRun(java("""
+				class Outer {
+
+					private final String field = "x";
+
+					static class Inner {
+					}
+
+					void method() {
+					}
+
+				}
+				""", """
+				class Outer {
+
+					private final String field = "x";
+
+					void method() {
+					}
+
+					static class Inner {
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void leavesAlreadyOrderedClassUntouched() {
+		this.rewriteRun(java("""
+				class Outer {
+
+					private final String field = "x";
+
+					void method() {
+					}
+
+					static class Inner {
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void preservesOrderingOfMultipleInnerTypesAmongstThemselves() {
+		this.rewriteRun(java("""
+				class Outer {
+
+					static class A {
+					}
+
+					void method() {
+					}
+
+					static class B {
+					}
+
+					private int field;
+
+					static class C {
+					}
+
+				}
+				""", """
+				class Outer {
+
+					void method() {
+					}
+
+					private int field;
+
+					static class A {
+					}
+
+					static class B {
+					}
+
+					static class C {
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void leavesClassWithOnlyInnerTypesAlone() {
+		this.rewriteRun(java("""
+				class Outer {
+
+					static class A {
+					}
+
+					static class B {
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void leavesClassWithOnlyMembersAlone() {
+		this.rewriteRun(java("""
+				class Outer {
+
+					int x;
+
+					void m() {
+					}
+
+				}
+				"""));
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/OverloadMethodsDeclarationOrderTests.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/OverloadMethodsDeclarationOrderTests.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class OverloadMethodsDeclarationOrderTests implements RewriteTest {
+
+	@Override
+	public void defaults(RecipeSpec spec) {
+		spec.recipe(new OverloadMethodsDeclarationOrder());
+	}
+
+	@Test
+	void groupsOverloadedMethodsTogether() {
+		this.rewriteRun(java("""
+				class Example {
+
+					void foo() {
+					}
+
+					void bar() {
+					}
+
+					void foo(int x) {
+					}
+
+				}
+				""", """
+				class Example {
+
+					void foo() {
+					}
+
+					void foo(int x) {
+					}
+
+					void bar() {
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void leavesAlreadyGroupedMethodsUntouched() {
+		this.rewriteRun(java("""
+				class Example {
+
+					void foo() {
+					}
+
+					void foo(int x) {
+					}
+
+					void bar() {
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void handlesMultipleOverloadGroups() {
+		this.rewriteRun(java("""
+				class Example {
+
+					void foo() {
+					}
+
+					void bar() {
+					}
+
+					void foo(int x) {
+					}
+
+					void bar(String s) {
+					}
+
+				}
+				""", """
+				class Example {
+
+					void foo() {
+					}
+
+					void foo(int x) {
+					}
+
+					void bar() {
+					}
+
+					void bar(String s) {
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void preservesNonMethodMembers() {
+		this.rewriteRun(java("""
+				class Example {
+
+					private int field;
+
+					void foo() {
+					}
+
+					private String name;
+
+					void foo(int x) {
+					}
+
+				}
+				""", """
+				class Example {
+
+					private int field;
+
+					void foo() {
+					}
+
+					void foo(int x) {
+					}
+
+					private String name;
+
+				}
+				"""));
+	}
+
+	@Test
+	void leavesClassWithNoOverloadsAlone() {
+		this.rewriteRun(java("""
+				class Example {
+
+					void foo() {
+					}
+
+					void bar() {
+					}
+
+					void baz() {
+					}
+
+				}
+				"""));
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/SpringCatchTests.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/SpringCatchTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class SpringCatchTests implements RewriteTest {
+
+	@Override
+	public void defaults(RecipeSpec spec) {
+		spec.recipe(new SpringCatch());
+	}
+
+	@Test
+	void renamesSingleLetterCatchVariableAndItsReferences() {
+		this.rewriteRun(java("""
+				class C {
+					void m() {
+						try {
+							throw new RuntimeException();
+						}
+						catch (Exception e) {
+							System.out.println(e.getMessage());
+							throw new RuntimeException(e);
+						}
+					}
+				}
+				""", """
+				class C {
+					void m() {
+						try {
+							throw new RuntimeException();
+						}
+						catch (Exception ex) {
+							System.out.println(ex.getMessage());
+							throw new RuntimeException(ex);
+						}
+					}
+				}
+				"""));
+	}
+
+	@Test
+	void leavesMultiCharCatchNameAlone() {
+		this.rewriteRun(java("""
+				class C {
+					void m() {
+						try {
+							throw new RuntimeException();
+						}
+						catch (Exception ex) {
+							System.out.println(ex.getMessage());
+						}
+					}
+				}
+				"""));
+	}
+
+	@Test
+	void doesNotRenameUnrelatedFieldNamedSameAsCatchParam() {
+		// The 'e' field on Math (Math.E is uppercase but consider general case);
+		// verify that an unrelated reference is not clobbered.
+		this.rewriteRun(java("""
+				class C {
+					int e = 5;
+
+					void m() {
+						try {
+							throw new RuntimeException();
+						}
+						catch (Exception e) {
+							System.out.println(e.getMessage());
+							System.out.println(this.e);
+						}
+					}
+				}
+				""", """
+				class C {
+					int e = 5;
+
+					void m() {
+						try {
+							throw new RuntimeException();
+						}
+						catch (Exception ex) {
+							System.out.println(ex.getMessage());
+							System.out.println(this.e);
+						}
+					}
+				}
+				"""));
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/SpringImportOrderTests.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/SpringImportOrderTests.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class SpringImportOrderTests implements RewriteTest {
+
+	@Override
+	public void defaults(RecipeSpec spec) {
+		spec.recipe(new SpringImportOrder());
+	}
+
+	@Test
+	void reordersJunitBeforeProjectImportThenSpringThenStatic() {
+		// Mirrors the real failing case: project import had been promoted ahead of
+		// other "third-party" imports and split with a blank line; Spring expects
+		// junit + project together (alphabetical), blank, then spring, blank, static.
+		this.rewriteRun(java("""
+				package org.springaicommunity.agentcore.ping;
+
+				import org.springaicommunity.agentcore.model.PingStatus;
+
+				import org.junit.jupiter.api.Test;
+				import org.springframework.http.HttpStatus;
+
+				import static org.assertj.core.api.Assertions.assertThat;
+				import static org.mockito.Mockito.mock;
+
+				class StaticAgentCorePingServiceTests {
+				}
+				""", """
+				package org.springaicommunity.agentcore.ping;
+
+				import org.junit.jupiter.api.Test;
+				import org.springaicommunity.agentcore.model.PingStatus;
+
+				import org.springframework.http.HttpStatus;
+
+				import static org.assertj.core.api.Assertions.assertThat;
+				import static org.mockito.Mockito.mock;
+
+				class StaticAgentCorePingServiceTests {
+				}
+				"""));
+	}
+
+	@Test
+	void leavesAlreadyOrderedImportsUntouched() {
+		this.rewriteRun(java("""
+				package com.example;
+
+				import java.util.List;
+				import java.util.Map;
+
+				import com.fasterxml.jackson.databind.ObjectMapper;
+
+				import org.springframework.http.HttpStatus;
+
+				import static org.junit.jupiter.api.Assertions.assertEquals;
+
+				class Stable {
+				}
+				"""));
+	}
+
+	@Test
+	void groupsJavaJavaxOtherSpring() {
+		this.rewriteRun(java("""
+				package com.example;
+
+				import org.springframework.boot.SpringApplication;
+				import javax.servlet.ServletException;
+				import com.fasterxml.jackson.databind.ObjectMapper;
+				import java.util.List;
+				import java.io.IOException;
+
+				class Mixed {
+				}
+				""", """
+				package com.example;
+
+				import java.io.IOException;
+				import java.util.List;
+
+				import javax.servlet.ServletException;
+
+				import com.fasterxml.jackson.databind.ObjectMapper;
+
+				import org.springframework.boot.SpringApplication;
+
+				class Mixed {
+				}
+				"""));
+	}
+
+	@Test
+	void putsAllStaticImportsAtBottomTogether() {
+		this.rewriteRun(java("""
+				package com.example;
+
+				import static java.util.Arrays.asList;
+				import org.junit.jupiter.api.Test;
+				import static org.assertj.core.api.Assertions.assertThat;
+
+				class StaticHandling {
+				}
+				""", """
+				package com.example;
+
+				import org.junit.jupiter.api.Test;
+
+				import static java.util.Arrays.asList;
+				import static org.assertj.core.api.Assertions.assertThat;
+
+				class StaticHandling {
+				}
+				"""));
+	}
+
+	@Test
+	void doesNothingWhenLessThanTwoImports() {
+		this.rewriteRun(java("""
+				package com.example;
+
+				import java.util.List;
+
+				class TooFew {
+				}
+				"""));
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/SpringLambdaTests.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/SpringLambdaTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class SpringLambdaTests implements RewriteTest {
+
+	@Override
+	public void defaults(RecipeSpec spec) {
+		spec.recipe(new SpringLambda());
+	}
+
+	@Test
+	void wrapsSingleArgWithoutParens() {
+		this.rewriteRun(java("""
+				import java.util.concurrent.atomic.AtomicReference;
+
+				class C {
+					void m(AtomicReference<String> r) {
+						r.updateAndGet(current -> current + "x");
+					}
+				}
+				""", """
+				import java.util.concurrent.atomic.AtomicReference;
+
+				class C {
+					void m(AtomicReference<String> r) {
+						r.updateAndGet((current) -> current + "x");
+					}
+				}
+				"""));
+	}
+
+	@Test
+	void leavesAlreadyParenthesizedSingleArgAlone() {
+		this.rewriteRun(java("""
+				import java.util.concurrent.atomic.AtomicReference;
+
+				class C {
+					void m(AtomicReference<String> r) {
+						r.updateAndGet((current) -> current + "x");
+					}
+				}
+				"""));
+	}
+
+	@Test
+	void leavesZeroArgLambdaAlone() {
+		this.rewriteRun(java("""
+				import java.util.function.Supplier;
+
+				class C {
+					void m() {
+						Supplier<String> s = () -> "x";
+					}
+				}
+				"""));
+	}
+
+	@Test
+	void leavesMultiArgLambdaAlone() {
+		this.rewriteRun(java("""
+				import java.util.function.BiFunction;
+
+				class C {
+					void m() {
+						BiFunction<String, String, String> f = (a, b) -> a + b;
+					}
+				}
+				"""));
+	}
+
+	@Test
+	void wrapsSingleArgWithBlockBody() {
+		this.rewriteRun(java("""
+				import java.util.concurrent.atomic.AtomicReference;
+
+				class C {
+					void m(AtomicReference<Integer> r) {
+						r.updateAndGet(current -> {
+							return current + 1;
+						});
+					}
+				}
+				""", """
+				import java.util.concurrent.atomic.AtomicReference;
+
+				class C {
+					void m(AtomicReference<Integer> r) {
+						r.updateAndGet((current) -> {
+							return current + 1;
+						});
+					}
+				}
+				"""));
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/SpringMethodVisibilityTests.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/SpringMethodVisibilityTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class SpringMethodVisibilityTests implements RewriteTest {
+
+	@Override
+	public void defaults(RecipeSpec spec) {
+		spec.recipe(new SpringMethodVisibility());
+	}
+
+	@Test
+	void removesPublicFromMethodInPackagePrivateClass() {
+		this.rewriteRun(java("""
+				class Outer {
+
+					public String getData() {
+						return "data";
+					}
+
+				}
+				""", """
+				class Outer {
+
+					String getData() {
+						return "data";
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void removesPublicFromMethodInPrivateInnerClass() {
+		this.rewriteRun(java("""
+				public class Outer {
+
+					private static class Inner {
+
+						public String getValue() {
+							return "value";
+						}
+
+					}
+
+				}
+				""", """
+				public class Outer {
+
+					private static class Inner {
+
+						String getValue() {
+							return "value";
+						}
+
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void leavesPublicMethodInPublicClass() {
+		this.rewriteRun(java("""
+				public class Outer {
+
+					public String getData() {
+						return "data";
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void leavesOverrideMethodUntouched() {
+		this.rewriteRun(java("""
+				class Outer {
+
+					@Override
+					public String toString() {
+						return "outer";
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void preservesOtherModifiers() {
+		this.rewriteRun(java("""
+				class Outer {
+
+					public static String helper() {
+						return "help";
+					}
+
+				}
+				""", """
+				class Outer {
+
+					static String helper() {
+						return "help";
+					}
+
+				}
+				"""));
+	}
+
+	@Test
+	void leavesMethodsInInterfaceNestedRecordUntouched() {
+		this.rewriteRun(java("""
+				public interface MyInterface {
+
+					record Result(String value) {
+
+						public boolean isEmpty() {
+							return this.value == null;
+						}
+
+					}
+
+				}
+				"""));
+	}
+
+}

--- a/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/SpringTernaryTests.java
+++ b/build-tools/spring-ai-agentcore-rewrite-recipes/src/test/java/org/springaicommunity/agentcore/rewrite/SpringTernaryTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.rewrite;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class SpringTernaryTests implements RewriteTest {
+
+	@Override
+	public void defaults(RecipeSpec spec) {
+		spec.recipe(new SpringTernary());
+	}
+
+	@Test
+	void wrapsUnparenthesizedNotEqualCondition() {
+		this.rewriteRun(java("""
+				class C {
+					int sizeOf(Object[] arr) {
+						return arr != null ? arr.length : 0;
+					}
+				}
+				""", """
+				class C {
+					int sizeOf(Object[] arr) {
+						return (arr != null) ? arr.length : 0;
+					}
+				}
+				"""));
+	}
+
+	@Test
+	void flipsEqualToNotEqualAndSwapsBranches() {
+		this.rewriteRun(java("""
+				class C {
+					int sizeOf(Object[] arr) {
+						return arr == null ? 0 : arr.length;
+					}
+				}
+				""", """
+				class C {
+					int sizeOf(Object[] arr) {
+						return (arr != null) ? arr.length : 0;
+					}
+				}
+				"""));
+	}
+
+	@Test
+	void leavesAlreadyParenthesizedNotEqualAlone() {
+		this.rewriteRun(java("""
+				class C {
+					int sizeOf(Object[] arr) {
+						return (arr != null) ? arr.length : 0;
+					}
+				}
+				"""));
+	}
+
+	@Test
+	void wrapsNonComparisonCondition() {
+		this.rewriteRun(java("""
+				class C {
+					String pick(boolean b) {
+						return b ? "yes" : "no";
+					}
+				}
+				""", """
+				class C {
+					String pick(boolean b) {
+						return (b) ? "yes" : "no";
+					}
+				}
+				"""));
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <packaging>pom</packaging>
     <url>https://github.com/spring-ai-community/spring-ai-agentcore</url>
     <modules>
+        <module>build-tools/spring-ai-agentcore-rewrite-recipes</module>
         <module>spring-ai-agentcore-bom</module>
         <module>spring-ai-agentcore-common</module>
         <module>spring-ai-agentcore-artifact-store</module>
@@ -133,6 +134,100 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.spring.javaformat</groupId>
+                        <artifactId>spring-javaformat-checkstyle</artifactId>
+                        <version>${spring-javaformat-maven-plugin.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>checkstyle-validation</id>
+                        <phase>validate</phase>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <configLocation>${maven.multiModuleProjectDirectory}/build-tools/checkstyle/checkstyle.xml</configLocation>
+                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                            <!-- TODO: flip to true once all violations are fixed -->
+                            <failOnViolation>false</failOnViolation>
+                            <consoleOutput>true</consoleOutput>
+                            <logViolationsToConsole>true</logViolationsToConsole>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>4.6</version>
+                <configuration>
+                    <header>${maven.multiModuleProjectDirectory}/build-tools/license/apache-2.0-header.txt</header>
+                    <includes>
+                        <include>**/*.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/build-tools/**</exclude>
+                    </excludes>
+                    <mapping>
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
+                    <strictCheck>true</strictCheck>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>license-check</id>
+                        <!-- TODO: bind to validate phase once headers are applied -->
+                        <phase>none</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>6.40.0</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>org.openrewrite.staticanalysis.ExplicitThis</recipe>
+                        <recipe>org.openrewrite.staticanalysis.LambdaBlockToExpression</recipe>
+                        <recipe>org.openrewrite.staticanalysis.SimplifyBooleanExpression</recipe>
+                        <recipe>org.openrewrite.staticanalysis.SimplifyBooleanReturn</recipe>
+                        <recipe>org.openrewrite.staticanalysis.MissingOverrideAnnotation</recipe>
+                        <recipe>org.openrewrite.staticanalysis.NoFinalizer</recipe>
+                        <recipe>org.springaicommunity.agentcore.rewrite.SpringImportOrder</recipe>
+                        <recipe>org.springaicommunity.agentcore.rewrite.SpringLambda</recipe>
+                        <recipe>org.springaicommunity.agentcore.rewrite.InnerTypeLast</recipe>
+                        <recipe>org.springaicommunity.agentcore.rewrite.SpringTernary</recipe>
+                        <recipe>org.springaicommunity.agentcore.rewrite.SpringCatch</recipe>
+                        <recipe>org.springaicommunity.agentcore.rewrite.SpringMethodVisibility</recipe>
+                        <recipe>org.springaicommunity.agentcore.rewrite.OverloadMethodsDeclarationOrder</recipe>
+                        <recipe>org.openrewrite.java.RemoveUnusedImports</recipe>
+                        <recipe>org.openrewrite.java.ShortenFullyQualifiedTypeReferences</recipe>
+                    </activeRecipes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-static-analysis</artifactId>
+                        <version>2.35.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.springaicommunity</groupId>
+                        <artifactId>spring-ai-agentcore-rewrite-recipes</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Adds build-time code quality tooling under `build-tools/`:

- **Checkstyle**: Spring base config + naming/sizing/bug-catcher rules (`failOnViolation=false` for now)
- **OpenRewrite**: 15 active recipes (6 off-the-shelf + 7 custom with 33 tests) for auto-fixing style violations
- **License plugin**: Apache 2.0 header template (not yet enforced)

No existing source files are modified. Enforcement and fixes come in follow-up PRs.

```bash
# Developer workflow after merge:
mvn rewrite:run                            # auto-fix style
mvn spring-javaformat:apply                # auto-fix formatting
mvn clean verify                           # check everything
```