### PR TITLE
Add Javadoc, package-info files, license headers, update copyright year

### DIFF
--- a/examples/simple-spring-boot-app/src/main/java/com/example/agent/ChatAgentService.java
+++ b/examples/simple-spring-boot-app/src/main/java/com/example/agent/ChatAgentService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.agent;
 
 import jakarta.annotation.PreDestroy;

--- a/examples/simple-spring-boot-app/src/main/java/com/example/agent/SimpleAgentApplication.java
+++ b/examples/simple-spring-boot-app/src/main/java/com/example/agent/SimpleAgentApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.agent;
 
 import org.springframework.boot.SpringApplication;

--- a/examples/spring-ai-browser/src/main/java/com/unicorn/browser/BrowserExampleApplication.java
+++ b/examples/spring-ai-browser/src/main/java/com/unicorn/browser/BrowserExampleApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/spring-ai-evaluations/src/main/java/com/example/evaluations/ChatController.java
+++ b/examples/spring-ai-evaluations/src/main/java/com/example/evaluations/ChatController.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.evaluations;
 
 import java.util.List;

--- a/examples/spring-ai-evaluations/src/main/java/com/example/evaluations/EvaluationsExampleApplication.java
+++ b/examples/spring-ai-evaluations/src/main/java/com/example/evaluations/EvaluationsExampleApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.evaluations;
 
 import org.springframework.boot.SpringApplication;

--- a/examples/spring-ai-extended-chat-client/src/main/java/org/springaicommunity/example/agent/DateTimeTools.java
+++ b/examples/spring-ai-extended-chat-client/src/main/java/org/springaicommunity/example/agent/DateTimeTools.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.example.agent;
 
 import java.time.LocalDateTime;

--- a/examples/spring-ai-extended-chat-client/src/main/java/org/springaicommunity/example/agent/ExtendedAgentsApplication.java
+++ b/examples/spring-ai-extended-chat-client/src/main/java/org/springaicommunity/example/agent/ExtendedAgentsApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.example.agent;
 
 import org.springframework.boot.SpringApplication;

--- a/examples/spring-ai-extended-chat-client/src/main/java/org/springaicommunity/example/agent/ExtendedChatController.java
+++ b/examples/spring-ai-extended-chat-client/src/main/java/org/springaicommunity/example/agent/ExtendedChatController.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.example.agent;
 
 import org.springaicommunity.agentcore.annotation.AgentCoreInvocation;

--- a/examples/spring-ai-extended-chat-client/src/main/java/org/springaicommunity/example/agent/JwtUtil.java
+++ b/examples/spring-ai-extended-chat-client/src/main/java/org/springaicommunity/example/agent/JwtUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.example.agent;
 
 import org.slf4j.Logger;

--- a/examples/spring-ai-extended-chat-client/src/test/java/org/springaicommunity/example/agent/JwtUtilTests.java
+++ b/examples/spring-ai-extended-chat-client/src/test/java/org/springaicommunity/example/agent/JwtUtilTests.java
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.example.agent;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class JwtUtilTests {
 

--- a/examples/spring-ai-memory-integration/src/main/java/org/springaicommunity/example/AgentCoreMemoryApplication.java
+++ b/examples/spring-ai-memory-integration/src/main/java/org/springaicommunity/example/AgentCoreMemoryApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.example;
 
 import org.springframework.boot.SpringApplication;

--- a/examples/spring-ai-memory-integration/src/main/java/org/springaicommunity/example/ChatController.java
+++ b/examples/spring-ai-memory-integration/src/main/java/org/springaicommunity/example/ChatController.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.example;
 
 import java.util.Comparator;

--- a/examples/spring-ai-memory-integration/src/test/java/org/springaicommunity/example/test/SetupTeardown.java
+++ b/examples/spring-ai-memory-integration/src/test/java/org/springaicommunity/example/test/SetupTeardown.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.example.test;
 
 import org.springframework.boot.CommandLineRunner;
@@ -5,7 +20,15 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import software.amazon.awssdk.services.bedrockagentcorecontrol.BedrockAgentCoreControlClient;
-import software.amazon.awssdk.services.bedrockagentcorecontrol.model.*;
+import software.amazon.awssdk.services.bedrockagentcorecontrol.model.CreateMemoryRequest;
+import software.amazon.awssdk.services.bedrockagentcorecontrol.model.DeleteMemoryRequest;
+import software.amazon.awssdk.services.bedrockagentcorecontrol.model.GetMemoryRequest;
+import software.amazon.awssdk.services.bedrockagentcorecontrol.model.Memory;
+import software.amazon.awssdk.services.bedrockagentcorecontrol.model.MemoryStatus;
+import software.amazon.awssdk.services.bedrockagentcorecontrol.model.MemoryStrategyInput;
+import software.amazon.awssdk.services.bedrockagentcorecontrol.model.ModifyMemoryStrategies;
+import software.amazon.awssdk.services.bedrockagentcorecontrol.model.SummaryMemoryStrategyInput;
+import software.amazon.awssdk.services.bedrockagentcorecontrol.model.UpdateMemoryRequest;
 
 import java.time.Duration;
 import java.util.List;

--- a/examples/spring-ai-override-invocations/src/main/java/com/unicorn/OverrideInvocationsApplication.java
+++ b/examples/spring-ai-override-invocations/src/main/java/com/unicorn/OverrideInvocationsApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn;
 
 import org.springframework.boot.SpringApplication;

--- a/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/CustomAgentCoreInvocationsController.java
+++ b/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/CustomAgentCoreInvocationsController.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn.agents;
 
 import org.springaicommunity.agentcore.controller.AgentCoreInvocationsHandler;

--- a/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/DateTimeTools.java
+++ b/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/DateTimeTools.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn.agents;
 
 import java.time.LocalDateTime;

--- a/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/PromptRequest.java
+++ b/examples/spring-ai-override-invocations/src/main/java/com/unicorn/agents/PromptRequest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn.agents;
 
 public record PromptRequest(String prompt){}

--- a/examples/spring-ai-override-invocations/src/test/java/com/unicorn/agents/OverrideInvocationsApplicationTests.java
+++ b/examples/spring-ai-override-invocations/src/test/java/com/unicorn/agents/OverrideInvocationsApplicationTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn.agents;
 
 import org.junit.jupiter.api.Test;

--- a/examples/spring-ai-simple-chat-client/src/main/java/com/unicorn/AgentsApplication.java
+++ b/examples/spring-ai-simple-chat-client/src/main/java/com/unicorn/AgentsApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn;
 
 import org.springframework.boot.SpringApplication;

--- a/examples/spring-ai-simple-chat-client/src/main/java/com/unicorn/agents/ChatController.java
+++ b/examples/spring-ai-simple-chat-client/src/main/java/com/unicorn/agents/ChatController.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn.agents;
 
 import org.slf4j.Logger;

--- a/examples/spring-ai-simple-chat-client/src/main/java/com/unicorn/agents/DateTimeTools.java
+++ b/examples/spring-ai-simple-chat-client/src/main/java/com/unicorn/agents/DateTimeTools.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn.agents;
 
 import java.time.LocalDateTime;

--- a/examples/spring-ai-simple-chat-client/src/main/java/com/unicorn/agents/PromptRequest.java
+++ b/examples/spring-ai-simple-chat-client/src/main/java/com/unicorn/agents/PromptRequest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn.agents;
 
 public record PromptRequest(String prompt){};

--- a/examples/spring-ai-simple-chat-client/src/test/java/com/unicorn/agents/AgentsApplicationTests.java
+++ b/examples/spring-ai-simple-chat-client/src/test/java/com/unicorn/agents/AgentsApplicationTests.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/examples/spring-ai-sse-chat-client/src/main/java/com/unicorn/SseAgentsApplication.java
+++ b/examples/spring-ai-sse-chat-client/src/main/java/com/unicorn/SseAgentsApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn;
 
 import org.springframework.boot.SpringApplication;

--- a/examples/spring-ai-sse-chat-client/src/main/java/com/unicorn/agents/DateTimeTools.java
+++ b/examples/spring-ai-sse-chat-client/src/main/java/com/unicorn/agents/DateTimeTools.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn.agents;
 
 import java.time.LocalDateTime;

--- a/examples/spring-ai-sse-chat-client/src/main/java/com/unicorn/agents/PromptRequest.java
+++ b/examples/spring-ai-sse-chat-client/src/main/java/com/unicorn/agents/PromptRequest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn.agents;
 
 public record PromptRequest(String prompt){}

--- a/examples/spring-ai-sse-chat-client/src/main/java/com/unicorn/agents/SseChatController.java
+++ b/examples/spring-ai-sse-chat-client/src/main/java/com/unicorn/agents/SseChatController.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn.agents;
 
 import org.slf4j.Logger;

--- a/examples/spring-ai-sse-chat-client/src/test/java/com/unicorn/agents/SseAgentsApplicationTests.java
+++ b/examples/spring-ai-sse-chat-client/src/test/java/com/unicorn/agents/SseAgentsApplicationTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.unicorn.agents;
 
 import org.junit.jupiter.api.Test;

--- a/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/ArtifactMetadata.java
+++ b/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/ArtifactMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/ArtifactStore.java
+++ b/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/ArtifactStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,55 +53,6 @@ public interface ArtifactStore<T> {
 	void store(String sessionId, String category, T artifact);
 
 	/**
-	 * Store multiple artifacts for a session and category.
-	 * @param sessionId the session ID
-	 * @param category the category
-	 * @param artifacts list of artifacts to store
-	 */
-	void storeAll(String sessionId, String category, List<T> artifacts);
-
-	/**
-	 * Retrieve and clear stored artifacts for a session and category (destructive read).
-	 * @param sessionId the session ID
-	 * @param category the category
-	 * @return list of artifacts, or null if none stored
-	 */
-	List<T> retrieve(String sessionId, String category);
-
-	/**
-	 * Peek at stored artifacts without removing them (non-destructive read).
-	 * @param sessionId the session ID
-	 * @param category the category
-	 * @return unmodifiable list of artifacts, or null if none stored
-	 */
-	List<T> peek(String sessionId, String category);
-
-	/**
-	 * Check if artifacts are stored for a session and category.
-	 * @param sessionId the session ID
-	 * @param category the category
-	 * @return true if artifacts are available
-	 */
-	boolean hasArtifacts(String sessionId, String category);
-
-	/**
-	 * Get the count of artifacts stored for a session and category.
-	 * @param sessionId the session ID
-	 * @param category the category
-	 * @return number of artifacts, or 0 if none stored
-	 */
-	int count(String sessionId, String category);
-
-	/**
-	 * Clear stored artifacts for a session and category without returning them.
-	 * @param sessionId the session ID
-	 * @param category the category
-	 */
-	void clear(String sessionId, String category);
-
-	// ========== Convenience methods using DEFAULT_CATEGORY ==========
-
-	/**
 	 * Store a single artifact for a session using default category.
 	 * @param sessionId the session ID
 	 * @param artifact the artifact to store
@@ -109,6 +60,14 @@ public interface ArtifactStore<T> {
 	default void store(String sessionId, T artifact) {
 		this.store(sessionId, DEFAULT_CATEGORY, artifact);
 	}
+
+	/**
+	 * Store multiple artifacts for a session and category.
+	 * @param sessionId the session ID
+	 * @param category the category
+	 * @param artifacts list of artifacts to store
+	 */
+	void storeAll(String sessionId, String category, List<T> artifacts);
 
 	/**
 	 * Store multiple artifacts for a session using default category.
@@ -120,6 +79,14 @@ public interface ArtifactStore<T> {
 	}
 
 	/**
+	 * Retrieve and clear stored artifacts for a session and category (destructive read).
+	 * @param sessionId the session ID
+	 * @param category the category
+	 * @return list of artifacts, or null if none stored
+	 */
+	List<T> retrieve(String sessionId, String category);
+
+	/**
 	 * Retrieve and clear stored artifacts for a session using default category.
 	 * @param sessionId the session ID
 	 * @return list of artifacts, or null if none stored
@@ -127,6 +94,14 @@ public interface ArtifactStore<T> {
 	default List<T> retrieve(String sessionId) {
 		return this.retrieve(sessionId, DEFAULT_CATEGORY);
 	}
+
+	/**
+	 * Peek at stored artifacts without removing them (non-destructive read).
+	 * @param sessionId the session ID
+	 * @param category the category
+	 * @return unmodifiable list of artifacts, or null if none stored
+	 */
+	List<T> peek(String sessionId, String category);
 
 	/**
 	 * Peek at stored artifacts using default category.
@@ -138,6 +113,14 @@ public interface ArtifactStore<T> {
 	}
 
 	/**
+	 * Check if artifacts are stored for a session and category.
+	 * @param sessionId the session ID
+	 * @param category the category
+	 * @return true if artifacts are available
+	 */
+	boolean hasArtifacts(String sessionId, String category);
+
+	/**
 	 * Check if artifacts are stored using default category.
 	 * @param sessionId the session ID
 	 * @return true if artifacts are available
@@ -147,6 +130,14 @@ public interface ArtifactStore<T> {
 	}
 
 	/**
+	 * Get the count of artifacts stored for a session and category.
+	 * @param sessionId the session ID
+	 * @param category the category
+	 * @return number of artifacts, or 0 if none stored
+	 */
+	int count(String sessionId, String category);
+
+	/**
 	 * Get the count of artifacts using default category.
 	 * @param sessionId the session ID
 	 * @return number of artifacts, or 0 if none stored
@@ -154,6 +145,13 @@ public interface ArtifactStore<T> {
 	default int count(String sessionId) {
 		return this.count(sessionId, DEFAULT_CATEGORY);
 	}
+
+	/**
+	 * Clear stored artifacts for a session and category without returning them.
+	 * @param sessionId the session ID
+	 * @param category the category
+	 */
+	void clear(String sessionId, String category);
 
 	/**
 	 * Clear stored artifacts using default category.

--- a/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/ArtifactStoreFactory.java
+++ b/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/ArtifactStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/CaffeineArtifactStore.java
+++ b/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/CaffeineArtifactStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/CaffeineArtifactStoreFactory.java
+++ b/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/CaffeineArtifactStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/GeneratedFile.java
+++ b/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/GeneratedFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,10 +53,10 @@ public record GeneratedFile(String mimeType, byte[] data, String name, Map<Strin
 
 	/**
 	 * Create a GeneratedFile with automatic timestamp metadata.
-	 * @param mimeType MIME type of the file
+	 * @param mimeType the MIME type of the file
 	 * @param data raw bytes of the file content
 	 * @param name filename
-	 * @return GeneratedFile with timestamp in metadata
+	 * @return generated file with timestamp in metadata
 	 */
 	public static GeneratedFile withTimestamp(String mimeType, byte[] data, String name) {
 		return new GeneratedFile(mimeType, data, name,
@@ -69,7 +69,7 @@ public record GeneratedFile(String mimeType, byte[] data, String name, Map<Strin
 	 */
 	@Override
 	public byte[] data() {
-		return Arrays.copyOf(this.data, data.length);
+		return Arrays.copyOf(this.data, this.data.length);
 	}
 
 	/**

--- a/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/SessionConstants.java
+++ b/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/SessionConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/package-info.java
+++ b/spring-ai-agentcore-artifact-store/src/main/java/org/springaicommunity/agentcore/artifacts/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * session-scoped artifact storage for files produced during tool execution.
+ */
+package org.springaicommunity.agentcore.artifacts;

--- a/spring-ai-agentcore-artifact-store/src/test/java/org/springaicommunity/agentcore/artifacts/ArtifactMetadataTests.java
+++ b/spring-ai-agentcore-artifact-store/src/test/java/org/springaicommunity/agentcore/artifacts/ArtifactMetadataTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-artifact-store/src/test/java/org/springaicommunity/agentcore/artifacts/CaffeineArtifactStoreFactoryTests.java
+++ b/spring-ai-agentcore-artifact-store/src/test/java/org/springaicommunity/agentcore/artifacts/CaffeineArtifactStoreFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-artifact-store/src/test/java/org/springaicommunity/agentcore/artifacts/CaffeineArtifactStoreTests.java
+++ b/spring-ai-agentcore-artifact-store/src/test/java/org/springaicommunity/agentcore/artifacts/CaffeineArtifactStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-artifact-store/src/test/java/org/springaicommunity/agentcore/artifacts/GeneratedFileTests.java
+++ b/spring-ai-agentcore-artifact-store/src/test/java/org/springaicommunity/agentcore/artifacts/GeneratedFileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserAutoConfiguration.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserClient.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public class AgentCoreBrowserClient implements BrowserClient {
 	/**
 	 * Take a screenshot of a web page and return raw bytes.
 	 * @param url the URL to navigate to
-	 * @return PNG bytes
+	 * @return raw PNG bytes
 	 * @throws BrowserOperationException if screenshot capture fails
 	 */
 	@Override
@@ -115,7 +115,7 @@ public class AgentCoreBrowserClient implements BrowserClient {
 	/**
 	 * Click an element on a web page.
 	 * @param url the URL to navigate to
-	 * @param selector CSS selector for the element to click
+	 * @param selector the CSS selector for the element to click
 	 * @return result message
 	 */
 	@Override
@@ -133,7 +133,7 @@ public class AgentCoreBrowserClient implements BrowserClient {
 	/**
 	 * Fill a form field on a web page.
 	 * @param url the URL to navigate to
-	 * @param selector CSS selector for the input field
+	 * @param selector the CSS selector for the input field
 	 * @param value value to fill
 	 * @return result message
 	 */
@@ -149,7 +149,7 @@ public class AgentCoreBrowserClient implements BrowserClient {
 	/**
 	 * Execute JavaScript on a web page.
 	 * @param url the URL to navigate to
-	 * @param script JavaScript code to execute
+	 * @param script the JavaScript code to execute
 	 * @return script result as string
 	 */
 	@Override

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserConfiguration.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/BrowseUrlRequest.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/BrowseUrlRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/BrowserArtifacts.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/BrowserArtifacts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,11 +43,11 @@ public final class BrowserArtifacts {
 
 	/**
 	 * Create a browser screenshot with full metadata.
-	 * @param data PNG bytes
+	 * @param data raw PNG bytes
 	 * @param url source URL
 	 * @param width viewport width
 	 * @param height viewport height
-	 * @return GeneratedFile with screenshot metadata
+	 * @return generated file with screenshot metadata
 	 */
 	public static GeneratedFile screenshot(byte[] data, String url, int width, int height) {
 		Map<String, String> meta = ArtifactMetadata.withTimestamp(META_URL, url, META_WIDTH, String.valueOf(width),

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/BrowserClient.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/BrowserClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public interface BrowserClient {
 	/**
 	 * Take a screenshot of a web page and return raw bytes.
 	 * @param url the URL to navigate to
-	 * @return PNG bytes
+	 * @return raw PNG bytes
 	 * @throws BrowserOperationException if screenshot capture fails
 	 */
 	byte[] screenshotBytes(String url);
@@ -43,7 +43,7 @@ public interface BrowserClient {
 	/**
 	 * Click an element on a web page.
 	 * @param url the URL to navigate to
-	 * @param selector CSS selector for the element to click
+	 * @param selector the CSS selector for the element to click
 	 * @return result message
 	 * @throws BrowserOperationException if the operation fails
 	 */
@@ -52,7 +52,7 @@ public interface BrowserClient {
 	/**
 	 * Fill a form field on a web page.
 	 * @param url the URL to navigate to
-	 * @param selector CSS selector for the input field
+	 * @param selector the CSS selector for the input field
 	 * @param value value to fill
 	 * @return result message
 	 * @throws BrowserOperationException if the operation fails
@@ -62,7 +62,7 @@ public interface BrowserClient {
 	/**
 	 * Execute JavaScript on a web page.
 	 * @param url the URL to navigate to
-	 * @param script JavaScript code to execute
+	 * @param script the JavaScript code to execute
 	 * @return script result as string
 	 * @throws BrowserOperationException if the operation fails
 	 */

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/BrowserOperationException.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/BrowserOperationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/BrowserTools.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/BrowserTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,26 +42,41 @@ public class BrowserTools {
 	 */
 	public static final String CATEGORY = "browser";
 
+	/**
+	 * tool description for the browse-and-extract tool advertised to LLMs.
+	 */
 	public static final String BROWSE_URL_DESCRIPTION = """
 			Browse a web page and extract its text content.
 			Returns the page title and body text.
 			""";
 
+	/**
+	 * tool description for the screenshot tool advertised to LLMs.
+	 */
 	public static final String SCREENSHOT_DESCRIPTION = """
 			Take a screenshot of a web page.
 			Returns metadata about the captured image. Screenshot is stored for retrieval.
 			""";
 
+	/**
+	 * tool description for the click tool advertised to LLMs.
+	 */
 	public static final String CLICK_DESCRIPTION = """
 			Click an element on a web page.
 			Selector is a CSS selector (for example, 'button', '#submit', '.btn-primary').
 			""";
 
+	/**
+	 * tool description for the fill-form tool advertised to LLMs.
+	 */
 	public static final String FILL_DESCRIPTION = """
 			Fill a form field on a web page.
 			Selector is a CSS selector for the input field.
 			""";
 
+	/**
+	 * tool description for the evaluate-script tool advertised to LLMs.
+	 */
 	public static final String EVALUATE_DESCRIPTION = """
 			Execute JavaScript on a web page and return the result.
 			""";
@@ -158,7 +173,7 @@ public class BrowserTools {
 	/**
 	 * Click an element on a web page.
 	 * @param url the URL to navigate to
-	 * @param selector CSS selector for the element
+	 * @param selector the CSS selector for the element
 	 * @return result message
 	 */
 	public String clickElement(String url, String selector) {
@@ -175,7 +190,7 @@ public class BrowserTools {
 	/**
 	 * Fill a form field on a web page.
 	 * @param url the URL to navigate to
-	 * @param selector CSS selector for the input
+	 * @param selector the CSS selector for the input
 	 * @param value value to fill
 	 * @return result message
 	 */
@@ -193,7 +208,7 @@ public class BrowserTools {
 	/**
 	 * Execute JavaScript on a web page.
 	 * @param url the URL to navigate to
-	 * @param script JavaScript code
+	 * @param script the JavaScript code
 	 * @return script result
 	 */
 	public String evaluateScript(String url, String script) {

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/ClickRequest.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/ClickRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/EvaluateRequest.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/EvaluateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/FillRequest.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/FillRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/LocalBrowserClient.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/LocalBrowserClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/PageContentFormatter.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/PageContentFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/ScreenshotRequest.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/ScreenshotRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/package-info.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * spring AI tools for the AgentCore browser automation service.
+ */
+package org.springaicommunity.agentcore.browser;

--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserTestConfiguration.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserTestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserArtifactsTests.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserArtifactsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserChatFlowIT.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserChatFlowIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserToolsIT.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserToolsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/LocalBrowserClientTests.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/LocalBrowserClientTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/LocalBrowserToolsIT.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/LocalBrowserToolsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterAutoConfiguration.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterClient.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import software.amazon.awssdk.services.bedrockagentcore.model.CodeInterpreterRes
 import software.amazon.awssdk.services.bedrockagentcore.model.ContentBlock;
 import software.amazon.awssdk.services.bedrockagentcore.model.InvokeCodeInterpreterRequest;
 import software.amazon.awssdk.services.bedrockagentcore.model.InvokeCodeInterpreterResponseHandler;
-import software.amazon.awssdk.services.bedrockagentcore.model.ResourceContent;
+import software.amazon.awssdk.services.bedrockagentcore.model.InvokeCodeInterpreterResponseHandler.Visitor;
 import software.amazon.awssdk.services.bedrockagentcore.model.StartCodeInterpreterSessionRequest;
 import software.amazon.awssdk.services.bedrockagentcore.model.StopCodeInterpreterSessionRequest;
 import software.amazon.awssdk.services.bedrockagentcore.model.ToolArguments;
@@ -140,11 +140,10 @@ public class AgentCoreCodeInterpreterClient {
 						.arguments(ToolArguments.builder().language(language).code(code).build())
 						.build(),
 					InvokeCodeInterpreterResponseHandler.builder()
-						.onEventStream((publisher) -> publisher
-							.subscribe((event) -> event.accept(InvokeCodeInterpreterResponseHandler.Visitor.builder()
-								.onResult((result) -> this.processResult(result, isError, textOutput, files))
-								.onDefault((defaultEvent) -> logger.trace("Default event: {}", defaultEvent))
-								.build())))
+						.onEventStream((publisher) -> publisher.subscribe((event) -> event.accept(Visitor.builder()
+							.onResult((result) -> this.processResult(result, isError, textOutput, files))
+							.onDefault((defaultEvent) -> logger.trace("Default event: {}", defaultEvent))
+							.build())))
 						.onError((error) -> {
 							logger.error("Stream error", error);
 							errorMessage.set(error.getMessage());
@@ -280,21 +279,9 @@ public class AgentCoreCodeInterpreterClient {
 						.arguments(ToolArguments.builder().directoryPath(directoryPath).build())
 						.build(),
 					InvokeCodeInterpreterResponseHandler.builder()
-						.onEventStream((publisher) -> publisher.subscribe((event) -> event
-							.accept(InvokeCodeInterpreterResponseHandler.Visitor.builder().onResult((result) -> {
-								if (result.content() != null) {
-									result.content().forEach((content) -> {
-										// Handle resource_link type - extract path from
-										// uri
-										if (content.uri() != null) {
-											String path = this.extractFileNameFromUri(content.uri());
-											if (path != null && !path.isEmpty() && !this.isExcludedPath(path)) {
-												filePaths.add(path);
-											}
-										}
-									});
-								}
-							}).build())))
+						.onEventStream((publisher) -> publisher.subscribe((event) -> event.accept(Visitor.builder()
+							.onResult((result) -> this.collectFilePathsFromResult(result, filePaths))
+							.build())))
 						.onError((error) -> {
 							String errorMessage = "listFiles failed: " + error.getMessage();
 							logger.error(errorMessage, error);
@@ -311,8 +298,26 @@ public class AgentCoreCodeInterpreterClient {
 		return filePaths;
 	}
 
+	private void collectFilePathsFromResult(CodeInterpreterResult result, List<String> filePaths) {
+		if (result.content() == null) {
+			return;
+		}
+		result.content().forEach((content) -> {
+			// Handle resource_link type - extract path from uri
+			if (content.uri() != null) {
+				String path = this.extractFileNameFromUri(content.uri());
+				if (path != null && !path.isEmpty() && !this.isExcludedPath(path)) {
+					filePaths.add(path);
+				}
+			}
+		});
+	}
+
 	/**
 	 * Extract filename from a URI (handles file:// scheme and plain paths).
+	 * @param uri the URI or path to extract the filename from
+	 * @return the extracted filename, or {@code null} if the input is {@code null} or
+	 * empty
 	 */
 	private String extractFileNameFromUri(String uri) {
 		if (uri == null || uri.isEmpty()) {
@@ -343,10 +348,9 @@ public class AgentCoreCodeInterpreterClient {
 						.arguments(ToolArguments.builder().paths(paths).build())
 						.build(),
 					InvokeCodeInterpreterResponseHandler.builder()
-						.onEventStream((publisher) -> publisher
-							.subscribe((event) -> event.accept(InvokeCodeInterpreterResponseHandler.Visitor.builder()
-								.onResult((result) -> this.processResult(paths, result, files))
-								.build())))
+						.onEventStream((publisher) -> publisher.subscribe((event) -> event.accept(Visitor.builder()
+							.onResult((result) -> this.processResult(paths, result, files))
+							.build())))
 						.onError((error) -> {
 							String errorMessage = "readFiles failed: " + error.getMessage();
 							logger.error(errorMessage, error);

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterConfiguration.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/CodeExecutionResult.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/CodeExecutionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterArtifacts.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterArtifacts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,11 +37,11 @@ public final class CodeInterpreterArtifacts {
 
 	/**
 	 * Create a file from code interpreter with source path metadata.
-	 * @param mimeType MIME type
+	 * @param mimeType the MIME type
 	 * @param data file bytes
 	 * @param name filename
 	 * @param sourcePath original path in sandbox
-	 * @return GeneratedFile with source path metadata
+	 * @return generated file with source path metadata
 	 */
 	public static GeneratedFile fromPath(String mimeType, byte[] data, String name, String sourcePath) {
 		Map<String, String> meta = ArtifactMetadata.withTimestamp(META_SOURCE_PATH, sourcePath);

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterTools.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,9 @@ public class CodeInterpreterTools {
 
 	private static final Set<String> SUPPORTED_LANGUAGES = Set.of("python", "javascript", "typescript");
 
+	/**
+	 * default tool description advertising the code interpreter to LLMs.
+	 */
 	public static final String DEFAULT_TOOL_DESCRIPTION = """
 			Execute code in a secure sandbox environment.
 			Supported languages: python, javascript, typescript.

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/ExecuteCodeRequest.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/ExecuteCodeRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,5 +30,5 @@ public record ExecuteCodeRequest(@JsonProperty(
 		required = true) @JsonPropertyDescription("Programming language: python, javascript, or typescript") String language,
 
 		@JsonProperty(
-				required = true) @JsonPropertyDescription("Code to execute. Use print()/console.log() for output.") String code) {
+				required = true) @JsonPropertyDescription("Code to execute. Use print() for stdout output.") String code) {
 }

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/package-info.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * spring AI tools for the AgentCore code interpreter sandbox service.
+ */
+package org.springaicommunity.agentcore.codeinterpreter;

--- a/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterArtifactsTests.java
+++ b/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterArtifactsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterChatFlowIT.java
+++ b/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterChatFlowIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterToolsIT.java
+++ b/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterToolsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/AgentCoreUserAgentInterceptor.java
+++ b/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/AgentCoreUserAgentInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/UserAgentProvider.java
+++ b/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/UserAgentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/package-info.java
+++ b/spring-ai-agentcore-common/src/main/java/org/springaicommunity/agentcore/common/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * shared utilities and interceptors used across the agentcore modules.
+ */
+package org.springaicommunity.agentcore.common;

--- a/spring-ai-agentcore-common/src/test/java/org/springaicommunity/agentcore/common/UserAgentProviderTests.java
+++ b/spring-ai-agentcore-common/src/test/java/org/springaicommunity/agentcore/common/UserAgentProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationAdvisor.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationAdvisor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ import org.springframework.ai.chat.model.Generation;
  *
  * @author Andrei Shakirin
  */
-public class AgentCoreEvaluationAdvisor implements CallAdvisor, StreamAdvisor {
+public final class AgentCoreEvaluationAdvisor implements CallAdvisor, StreamAdvisor {
 
 	private static final Logger logger = LoggerFactory.getLogger(AgentCoreEvaluationAdvisor.class);
 
@@ -295,6 +295,8 @@ public class AgentCoreEvaluationAdvisor implements CallAdvisor, StreamAdvisor {
 	 * advisor), and {@code ToolResponseMessage} entries are included. Any intermediate
 	 * {@code AssistantMessage.toolCalls} from the current turn are not visible here, see
 	 * design doc Extension 5.1.
+	 * @param request the chat client request whose prompt history is being extracted
+	 * @return body-message entries for prior history (excluding the trailing user prompt)
 	 */
 	private List<Map<String, Object>> extractHistory(ChatClientRequest request) {
 		List<Message> all = request.prompt().getInstructions();
@@ -386,7 +388,7 @@ public class AgentCoreEvaluationAdvisor implements CallAdvisor, StreamAdvisor {
 		return this.order;
 	}
 
-	public static class Builder {
+	public static final class Builder {
 
 		private final AgentCoreEvaluationClient client;
 

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationAutoConfiguration.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,9 @@ import org.springframework.context.annotation.Bean;
 @EnableConfigurationProperties(AgentCoreEvaluationProperties.class)
 public class AgentCoreEvaluationAutoConfiguration {
 
+	/**
+	 * bean name for the evaluation executor service.
+	 */
 	public static final String EXECUTOR_BEAN_NAME = "agentCoreEvaluationExecutor";
 
 	@Bean(destroyMethod = "close")
@@ -66,6 +69,7 @@ public class AgentCoreEvaluationAutoConfiguration {
 	 * Default executor for asynchronous evaluations. Uses a virtual-thread-per-task
 	 * executor because evaluation work blocks on remote Bedrock calls; virtual threads
 	 * are cheap to park on I/O.
+	 * @return the evaluation executor service
 	 */
 	@Bean(name = EXECUTOR_BEAN_NAME, destroyMethod = "close")
 	@ConditionalOnMissingBean(name = EXECUTOR_BEAN_NAME)

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationMetrics.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationProperties.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,13 +41,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * — preserves the single-message baseline wire shape verified against the Evaluate API.
  * Opt-in because the multi-message payload grows with conversation length; long sessions
  * at high sample rates produce O(n²) bytes on the wire.
+ * @author Andrei Shakirin
  */
 @ConfigurationProperties(AgentCoreEvaluationProperties.CONFIG_PREFIX)
 public record AgentCoreEvaluationProperties(boolean enabled, String region, List<String> evaluatorIds, Boolean async,
 		Boolean metricsEnabled, Double sampleRate, Boolean includeHistory) {
 
+	/**
+	 * configuration prefix for evaluation properties.
+	 */
 	public static final String CONFIG_PREFIX = "spring.ai.agentcore.evaluations";
 
+	/**
+	 * default evaluator IDs used when none are configured.
+	 */
 	public static final List<String> DEFAULT_EVALUATOR_IDS = List.of("Builtin.Helpfulness");
 
 	public AgentCoreEvaluationProperties {

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClient.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,6 +131,9 @@ public class AgentCoreEvaluationClient {
 	 * resulting {@link EvaluationResult} carries an
 	 * {@code errorCode}/{@code errorMessage} instead of a score so {@link #evaluateAll}
 	 * never aborts because of a single evaluator failure.
+	 * @param evaluatorId the evaluator to invoke
+	 * @param sessionSpans the session spans payload
+	 * @return per-evaluator results, with an error entry on failure
 	 */
 	private List<EvaluationResult> evaluateWithErrorCapture(String evaluatorId,
 			List<Map<String, Object>> sessionSpans) {
@@ -184,7 +187,8 @@ public class AgentCoreEvaluationClient {
 		List<EvaluationResult> mapped = new ArrayList<>();
 		for (EvaluationResultContent result : results) {
 			logger.debug(
-					"API result - evaluatorId: {}, value: {}, label: {}, explanation: {}, errorCode: {}, errorMessage: {}",
+					"API result - evaluatorId: {}, value: {}, label: {}, explanation: {}, "
+							+ "errorCode: {}, errorMessage: {}",
 					result.evaluatorId(), result.value(), result.label(), result.explanation(), result.errorCode(),
 					result.errorMessage());
 

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/EvaluationEvent.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/EvaluationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.List;
  * @param results list of evaluation results from all evaluators
  * @param timestamp when the evaluation completed
  * @param latency how long the evaluation took
+ * @author Maximilian Schellhorn
  */
 public record EvaluationEvent(String sessionId, String traceId, List<EvaluationResult> results, Instant timestamp,
 		Duration latency) {

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/EvaluationResult.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/EvaluationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ package org.springaicommunity.agentcore.evaluations.client;
  * @param errorCode error code when the API could not produce a score (null on success)
  * @param errorMessage human-readable error detail when {@code errorCode} is set (null on
  * success)
+ * @author Maximilian Schellhorn
  */
 public record EvaluationResult(String evaluatorId, Double score, String label, String explanation, Integer inputTokens,
 		Integer outputTokens, String errorCode, String errorMessage) {

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/SpanEventBuilder.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/SpanEventBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *
  * @author Andrei Shakirin
  */
-public class SpanEventBuilder {
+public final class SpanEventBuilder {
 
 	/**
 	 * Instrumentation scope the Evaluate API recognises as a Strands agent source. We
@@ -136,6 +136,8 @@ public class SpanEventBuilder {
 	/**
 	 * Set the model id recorded on the agent span's {@code gen_ai.request.model}
 	 * attribute.
+	 * @param modelId the model identifier
+	 * @return this builder
 	 */
 	public SpanEventBuilder modelId(String modelId) {
 		if (modelId != null && !modelId.isBlank()) {
@@ -148,6 +150,8 @@ public class SpanEventBuilder {
 	 * Set the finish reason emitted in the assistant message's body (e.g.
 	 * {@code "end_turn"}, {@code "tool_use"}, {@code "max_tokens"}). Defaults to
 	 * {@code "end_turn"} when not set or when the value is blank.
+	 * @param finishReason the finish reason value
+	 * @return this builder
 	 */
 	public SpanEventBuilder finishReason(String finishReason) {
 		if (finishReason != null && !finishReason.isBlank()) {
@@ -162,6 +166,9 @@ public class SpanEventBuilder {
 	 * values are skipped — the corresponding attribute is omitted rather than set to
 	 * zero, since many providers return {@code null} when usage data is unavailable and a
 	 * hard zero would be misleading.
+	 * @param inputTokens prompt tokens consumed (may be {@code null})
+	 * @param outputTokens completion tokens produced (may be {@code null})
+	 * @return this builder
 	 */
 	public SpanEventBuilder tokenUsage(Integer inputTokens, Integer outputTokens) {
 		this.inputTokens = inputTokens;
@@ -175,6 +182,8 @@ public class SpanEventBuilder {
 	 * shape (keys {@code role} and {@code content}). Callers build this from Spring AI's
 	 * {@code List<Message>} before passing in. Passing {@code null} or an empty list is a
 	 * no-op and preserves the single-message baseline shape.
+	 * @param history prior messages in ADOT body shape
+	 * @return this builder
 	 */
 	public SpanEventBuilder history(List<Map<String, Object>> history) {
 		this.history = (history != null) ? history : List.of();

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/package-info.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * client classes for invoking the AgentCore Evaluate API.
+ */
+package org.springaicommunity.agentcore.evaluations.client;

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/package-info.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * spring AI integration with the AgentCore Evaluate API.
+ */
+package org.springaicommunity.agentcore.evaluations;

--- a/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationAdvisorTests.java
+++ b/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationAdvisorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationPropertiesTests.java
+++ b/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClientProbeIT.java
+++ b/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClientProbeIT.java
@@ -1,5 +1,17 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.springaicommunity.agentcore.evaluations.client;
 

--- a/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClientTests.java
+++ b/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClientTests.java
@@ -1,13 +1,18 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.springaicommunity.agentcore.evaluations.client;
 
 import java.util.HashMap;

--- a/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/EvaluationEventTests.java
+++ b/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/EvaluationEventTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/SpanEventBuilderTests.java
+++ b/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/SpanEventBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryConversationIdParser.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryConversationIdParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,9 @@ public final class AgentCoreMemoryConversationIdParser {
 
 	/**
 	 * Represents parsed actor and session from a conversationId.
+	 *
+	 * @param actor parsed actor identifier
+	 * @param session parsed session identifier
 	 */
 	public record ActorAndSession(String actor, String session) {
 	}

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryException.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springaicommunity.agentcore.memory;
 
 /**
  * Base exception for AgentCore Memory operations.
+ *
+ * @author Andrei Shakirin
  */
 public class AgentCoreMemoryException extends RuntimeException {
 

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryProperties.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record AgentCoreMemoryProperties(String memoryId, Integer totalEventsLimit, String defaultSession, int pageSize,
 		boolean ignoreUnknownRoles) {
 
+	/**
+	 * configuration prefix for memory properties.
+	 */
 	public static final String CONFIG_PREFIX = "agentcore.memory";
 
 	public AgentCoreMemoryProperties(String memoryId, Integer totalEventsLimit, String defaultSession, int pageSize,

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAdvisor.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAdvisor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ import org.springframework.ai.chat.memory.ChatMemory;
  *
  * @author Yuriy Bezsonov
  */
-public class AgentCoreLongTermMemoryAdvisor implements CallAdvisor, StreamAdvisor {
+public final class AgentCoreLongTermMemoryAdvisor implements CallAdvisor, StreamAdvisor {
 
 	private static final Logger logger = LoggerFactory.getLogger(AgentCoreLongTermMemoryAdvisor.class);
 
@@ -166,7 +166,7 @@ public class AgentCoreLongTermMemoryAdvisor implements CallAdvisor, StreamAdviso
 		return this.order;
 	}
 
-	public static class Builder {
+	public static final class Builder {
 
 		private final AgentCoreLongTermMemoryRetriever retriever;
 
@@ -185,6 +185,8 @@ public class AgentCoreLongTermMemoryAdvisor implements CallAdvisor, StreamAdviso
 		 * Supply the strategy handler that drives fetch / format / inject. Use one of the
 		 * built-in handlers or a user-provided implementation of
 		 * {@link MemoryStrategyHandler}.
+		 * @param handler the strategy handler
+		 * @return this builder
 		 */
 		public Builder handler(MemoryStrategyHandler handler) {
 			Objects.requireNonNull(handler, "handler is required");
@@ -198,6 +200,8 @@ public class AgentCoreLongTermMemoryAdvisor implements CallAdvisor, StreamAdviso
 		 * {@code AgentCoreLongTermMemoryAdvisor-SEMANTIC}) and the default advisor order.
 		 * Custom handlers can leave this unset; the advisor defaults to
 		 * {@link AgentCoreLongTermMemoryStrategyType#CUSTOM}.
+		 * @param memoryStrategy the built-in strategy type
+		 * @return this builder
 		 */
 		public Builder memoryStrategy(AgentCoreLongTermMemoryStrategyType memoryStrategy) {
 			Objects.requireNonNull(memoryStrategy, "memoryStrategy is required");

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAutoConfiguration.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -244,6 +244,8 @@ public class AgentCoreLongTermMemoryAutoConfiguration {
 	 * keyed by strategy id. Multiple namespaces per strategy are possible — e.g. episodic
 	 * strategies with reflections live under the same id but two namespaces. Used by the
 	 * startup namespace validator/registrar.
+	 * @param config the long-term memory configuration
+	 * @return map of strategy id to expected namespace patterns
 	 */
 	private Map<String, List<String>> collectNamespacesByStrategy(AgentCoreLongTermMemoryProperties config) {
 		Map<String, List<String>> namespacesByStrategy = new HashMap<>();

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAutoDiscoveryAdvisorFactory.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAutoDiscoveryAdvisorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,8 +112,8 @@ class AgentCoreLongTermMemoryAutoDiscoveryAdvisorFactory {
 				yield b.build();
 			}
 			case EPISODIC -> this.buildEpisodicHandler(discovered, explicitConfig, namespace);
-			case CUSTOM -> throw new IllegalStateException(
-					"Auto-discovery should never produce CUSTOM; AgentCoreLongTermMemoryStrategyType.fromAwsType filters it out.");
+			case CUSTOM -> throw new IllegalStateException("Auto-discovery should never produce CUSTOM; "
+					+ "AgentCoreLongTermMemoryStrategyType.fromAwsType filters it out.");
 		};
 	}
 

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryNamespace.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryNamespaceRegistrar.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryNamespaceRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryNamespaceValidator.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryNamespaceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryProperties.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(AgentCoreLongTermMemoryProperties.CONFIG_PREFIX)
 public class AgentCoreLongTermMemoryProperties {
 
+	/**
+	 * configuration prefix for long-term memory properties.
+	 */
 	public static final String CONFIG_PREFIX = "agentcore.memory.long-term";
 
 	private final boolean autoDiscovery;
@@ -77,6 +80,8 @@ public class AgentCoreLongTermMemoryProperties {
 	 * strategy kind, or {@code null} if no config applies.
 	 * {@link AgentCoreLongTermMemoryStrategyType#CUSTOM} has no matching config record by
 	 * design — user-defined handlers provide their own configuration.
+	 * @param kind the memory strategy kind
+	 * @return the matching strategy config record, or {@code null} if none applies
 	 */
 	public AgentCoreLongTermMemoryStrategy byKind(AgentCoreLongTermMemoryStrategyType kind) {
 		return switch (kind) {
@@ -93,6 +98,9 @@ public class AgentCoreLongTermMemoryProperties {
 			AgentCoreLongTermMemoryNamespace reflectionsNamespace,
 			String reflectionsNamespacePattern) implements AgentCoreLongTermMemoryStrategy {
 
+		/**
+		 * configuration prefix for the episodic strategy.
+		 */
 		public static final String CONFIG_PREFIX = AgentCoreLongTermMemoryProperties.CONFIG_PREFIX + ".episodic";
 
 		private static final Logger logger = LoggerFactory.getLogger(Episodic.class);
@@ -104,14 +112,21 @@ public class AgentCoreLongTermMemoryProperties {
 			if (reflectionsStrategyId != null && !reflectionsStrategyId.isEmpty()) {
 				boolean hasNamespaceOverride = (reflectionsNamespacePattern != null
 						&& !reflectionsNamespacePattern.isEmpty()) || reflectionsNamespace != null;
-				logger.warn("'reflections-strategy-id' is deprecated and will be removed in a future release. "
-						+ "In AWS AgentCore Memory, reflections are a namespace under the same episodic strategy, "
-						+ "not a separate strategy. Migrate to 'reflections-namespace-pattern' or "
-						+ "'reflections-namespace'. See: "
-						+ "https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/episodic-memory-strategy.html"
-						+ ((hasNamespaceOverride) ? " (Note: a reflections namespace is also set and takes precedence.)"
-								: ""));
+				logger.warn(buildDeprecatedReflectionsWarning(hasNamespaceOverride));
 			}
+		}
+
+		private static String buildDeprecatedReflectionsWarning(boolean hasNamespaceOverride) {
+			String message = "'reflections-strategy-id' is deprecated and will be removed in a future release. "
+					+ "In AWS AgentCore Memory, reflections are a namespace under the same episodic strategy, "
+					+ "not a separate strategy. Migrate to 'reflections-namespace-pattern' or "
+					+ "'reflections-namespace'. See: "
+					+ "https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/"
+					+ "episodic-memory-strategy.html";
+			if (hasNamespaceOverride) {
+				message += " (Note: a reflections namespace is also set and takes precedence.)";
+			}
+			return message;
 		}
 
 		@Override
@@ -121,6 +136,7 @@ public class AgentCoreLongTermMemoryProperties {
 		}
 
 		/**
+		 * Returns the deprecated reflections strategy id.
 		 * @deprecated Reflections in AWS AgentCore Memory are a namespace of the same
 		 * episodic strategy, not a separate strategy. Use {@link #reflectionsNamespace()}
 		 * or {@link #reflectionsNamespacePattern()} instead. Kept for one release for
@@ -153,6 +169,7 @@ public class AgentCoreLongTermMemoryProperties {
 		 * Returns true if reflections are configured via the deprecated separate-strategy
 		 * path and no modern configuration overrides it. Advisor + auto-config branch on
 		 * this to keep legacy behaviour alive while warning.
+		 * @return {@code true} if the legacy reflections strategy path is in use
 		 */
 		public boolean usesLegacyReflectionsStrategy() {
 			return this.resolveReflectionsNamespacePattern() == null && this.reflectionsStrategyId != null
@@ -164,6 +181,9 @@ public class AgentCoreLongTermMemoryProperties {
 	public record Semantic(String strategyId, int topK, AgentCoreLongTermMemoryNamespace namespace,
 			String namespacePattern) implements AgentCoreLongTermMemoryStrategy {
 
+		/**
+		 * configuration prefix for the semantic strategy.
+		 */
 		public static final String CONFIG_PREFIX = AgentCoreLongTermMemoryProperties.CONFIG_PREFIX + ".semantic";
 
 		public Semantic {
@@ -182,6 +202,9 @@ public class AgentCoreLongTermMemoryProperties {
 	public record Summary(String strategyId, int topK, AgentCoreLongTermMemoryNamespace namespace,
 			String namespacePattern) implements AgentCoreLongTermMemoryStrategy {
 
+		/**
+		 * configuration prefix for the summary strategy.
+		 */
 		public static final String CONFIG_PREFIX = AgentCoreLongTermMemoryProperties.CONFIG_PREFIX + ".summary";
 
 		public Summary {
@@ -200,6 +223,9 @@ public class AgentCoreLongTermMemoryProperties {
 	public record UserPreference(String strategyId, AgentCoreLongTermMemoryNamespace namespace,
 			String namespacePattern) implements AgentCoreLongTermMemoryStrategy {
 
+		/**
+		 * configuration prefix for the user-preference strategy.
+		 */
 		public static final String CONFIG_PREFIX = AgentCoreLongTermMemoryProperties.CONFIG_PREFIX + ".user-preference";
 
 		public UserPreference {

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryRetriever.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryRetriever.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,11 @@ public class AgentCoreLongTermMemoryRetriever {
 
 	/**
 	 * Semantic search for memories (actor-scoped, searches all sessions).
+	 * @param strategyId the memory strategy id
+	 * @param actorId the actor id
+	 * @param query the natural-language query
+	 * @param topK the maximum number of records to return
+	 * @return matching memory records
 	 */
 	public List<MemoryRecord> searchMemories(String strategyId, String actorId, String query, int topK) {
 		return this.searchMemories(strategyId, actorId, null, query, topK,
@@ -77,6 +82,10 @@ public class AgentCoreLongTermMemoryRetriever {
 
 	/**
 	 * List all memories for an actor (no semantic search). Used for preferences.
+	 * @param strategyId the memory strategy id
+	 * @param actorId the actor id
+	 * @param namespacePattern the namespace pattern to scope the listing
+	 * @return all matching memory records
 	 */
 	public List<MemoryRecord> listMemories(String strategyId, String actorId, String namespacePattern) {
 		String namespace = AgentCoreLongTermMemoryNamespace.buildNamespace(namespacePattern, strategyId, actorId, null);

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryStrategy.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryStrategyDiscovery.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryStrategyDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,6 +129,8 @@ public class AgentCoreLongTermMemoryStrategyDiscovery {
 	 * list when any link is missing or when the reflection variant is
 	 * {@code customReflectionConfiguration} (handled separately, not supported by
 	 * auto-discovery yet).
+	 * @param strategy the AWS memory strategy descriptor
+	 * @return the configured reflection namespaces, or empty when not applicable
 	 */
 	private List<String> extractReflectionsNamespaces(MemoryStrategy strategy) {
 		StrategyConfiguration configuration = strategy.configuration();
@@ -176,6 +178,7 @@ public class AgentCoreLongTermMemoryStrategyDiscovery {
 
 		/**
 		 * Returns the first namespace (default for episodes).
+		 * @return the default namespace
 		 */
 		public String defaultNamespace() {
 			return this.namespaces.get(0);
@@ -184,6 +187,7 @@ public class AgentCoreLongTermMemoryStrategyDiscovery {
 		/**
 		 * Returns the first reflections namespace, or {@code null} if none are
 		 * configured.
+		 * @return the default reflections namespace, or {@code null}
 		 */
 		public String defaultReflectionsNamespace() {
 			return (this.reflectionsNamespaces.isEmpty()) ? null : this.reflectionsNamespaces.get(0);

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryStrategyType.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryStrategyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,12 +38,16 @@ import software.amazon.awssdk.services.bedrockagentcorecontrol.model.MemoryStrat
  */
 public enum AgentCoreLongTermMemoryStrategyType {
 
+	/** known facts about the user. */
 	SEMANTIC(100, "Known facts about the user (use naturally in conversation)"),
 
+	/** user preferences applied during conversation. */
 	USER_PREFERENCE(200, "User preferences (apply when relevant)"),
 
+	/** previous conversation summaries used for continuity. */
 	SUMMARY(300, "Previous conversation summaries (use for continuity)"),
 
+	/** past interactions and reflections referenced when relevant. */
 	EPISODIC(400, "Past interactions and reflections (reference when relevant)"),
 
 	/**
@@ -61,6 +65,10 @@ public enum AgentCoreLongTermMemoryStrategyType {
 		this.contextLabel = contextLabel;
 	}
 
+	/**
+	 * Returns the relative ordering of this strategy in injected prompt sections.
+	 * @return the ordering value
+	 */
 	public int getOrder() {
 		return this.order;
 	}
@@ -68,6 +76,7 @@ public enum AgentCoreLongTermMemoryStrategyType {
 	/**
 	 * Human-readable label prefixing the injected memory section. Empty for
 	 * {@link #CUSTOM}.
+	 * @return the context label
 	 */
 	public String contextLabel() {
 		return this.contextLabel;
@@ -77,6 +86,8 @@ public enum AgentCoreLongTermMemoryStrategyType {
 	 * Maps an AWS SDK {@link MemoryStrategyType} to this enum. Returns {@code null} for
 	 * AWS types that have no direct advisor-side counterpart ({@code CUSTOM} on the AWS
 	 * side, or unknown SDK versions) — callers should skip such strategies.
+	 * @param awsType the AWS SDK strategy type
+	 * @return the matching advisor-side strategy type, or {@code null}
 	 */
 	public static AgentCoreLongTermMemoryStrategyType fromAwsType(MemoryStrategyType awsType) {
 		if (awsType == null) {

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreMemory.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,13 @@ import org.springframework.ai.chat.client.advisor.api.Advisor;
 
 public class AgentCoreMemory {
 
+	/** combined short-term memory advisor backed by the chat memory repository. */
 	public final MessageChatMemoryAdvisor shortTermMemoryAdvisor;
 
+	/** ordered list of long-term memory advisors, one per configured strategy. */
 	public final List<AgentCoreLongTermMemoryAdvisor> longTermMemoryAdvisors;
 
+	/** combined advisor list (short-term plus long-term) for chaining. */
 	public final List<Advisor> advisors;
 
 	public AgentCoreMemory(MessageChatMemoryAdvisor stmAdvisor, List<AgentCoreLongTermMemoryAdvisor> ltmAdvisors) {

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/package-info.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * long-term memory advisors backed by the AgentCore Memory service.
+ */
+package org.springaicommunity.agentcore.memory.longterm;

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/EpisodicMemoryStrategyHandler.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/EpisodicMemoryStrategyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ import org.springaicommunity.agentcore.memory.longterm.AgentCoreLongTermMemoryRe
  * namespace as episodes. Kept for one release; construction-time warning comes from the
  * properties record.</li>
  * </ul>
+ *
+ * @author Maximilian Schellhorn
  */
 public final class EpisodicMemoryStrategyHandler implements MemoryStrategyHandler {
 
@@ -154,6 +156,8 @@ public final class EpisodicMemoryStrategyHandler implements MemoryStrategyHandle
 		 * same {@code strategyId} as episodes but live under a (typically less nested)
 		 * namespace. Takes precedence over the deprecated
 		 * {@link #reflectionsStrategyId(String)}.
+		 * @param reflectionsNamespacePattern the namespace pattern for reflections
+		 * @return this builder
 		 */
 		public Builder reflectionsNamespacePattern(String reflectionsNamespacePattern) {
 			this.reflectionsNamespacePattern = reflectionsNamespacePattern;
@@ -164,6 +168,8 @@ public final class EpisodicMemoryStrategyHandler implements MemoryStrategyHandle
 		 * Legacy setter. In AWS AgentCore Memory, reflections are a namespace within the
 		 * same episodic strategy, not a separate strategy. Use
 		 * {@link #reflectionsNamespacePattern(String)} instead.
+		 * @param reflectionsStrategyId the legacy reflections strategy id
+		 * @return this builder
 		 * @deprecated will be removed in a future release
 		 */
 		@Deprecated(forRemoval = true)

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/MemoryStrategyHandler.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/MemoryStrategyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ import org.springframework.ai.chat.prompt.Prompt;
  * (semantic / user preference / summary / episodic) cover the standard AWS AgentCore
  * memory strategy types; the same interface will be reused by custom strategies in a
  * future release.
+ *
+ * @author Maximilian Schellhorn
  */
 public interface MemoryStrategyHandler {
 
@@ -44,12 +46,14 @@ public interface MemoryStrategyHandler {
 	 * Returns {@code true} when this strategy needs a non-empty user prompt to run. If
 	 * {@code false} (e.g. USER_PREFERENCE) the advisor will invoke this handler even on
 	 * empty prompts.
+	 * @return {@code true} if a non-empty user prompt is required
 	 */
 	default boolean requiresUserPrompt() {
 		return true;
 	}
 
 	/**
+	 * Returns the AgentCore Memory strategy id this handler reads from.
 	 * @return the AgentCore Memory strategy id this handler reads from.
 	 */
 	String strategyId();
@@ -67,11 +71,13 @@ public interface MemoryStrategyHandler {
 	 * @param context the same per-call inputs that drove the fetch, provided again so
 	 * implementations can interpolate the user prompt into the output if needed
 	 * @param fetched the non-empty result of {@link #fetch(MemoryFetchContext)}
+	 * @return the rendered memory section
 	 */
 	String format(MemoryFetchContext context, MemoryFetchResult fetched);
 
 	/**
 	 * Where the formatted context is placed on the outgoing request.
+	 * @return the injection target
 	 */
 	InjectionTarget target();
 
@@ -79,6 +85,9 @@ public interface MemoryStrategyHandler {
 	 * Default injection helper. Attaches {@code context} to the system message (creating
 	 * one if missing) or replaces the user message, per {@link #target()}.
 	 * Implementations normally don't need to override this.
+	 * @param request the chat client request being processed
+	 * @param context the rendered memory context
+	 * @return the request with the memory context injected
 	 */
 	default ChatClientRequest inject(ChatClientRequest request, String context) {
 		return switch (this.target()) {
@@ -100,6 +109,9 @@ public interface MemoryStrategyHandler {
 	 *
 	 * Built-in handlers use this to produce consistent prompt output; custom handlers may
 	 * reuse or replace it.
+	 * @param header the section header
+	 * @param records the records to render
+	 * @return the rendered memory section
 	 */
 	static String formatMemorySection(String header, List<MemoryRecord> records) {
 		StringBuilder sb = new StringBuilder();
@@ -165,6 +177,12 @@ public interface MemoryStrategyHandler {
 	 * Inputs the advisor computes once per turn and hands to the handler's
 	 * {@link #fetch(MemoryFetchContext)} and
 	 * {@link #format(MemoryFetchContext, MemoryFetchResult)}.
+	 *
+	 * @param retriever retriever used to query AgentCore Memory
+	 * @param userId resolved user (actor) id for the current turn
+	 * @param sessionId resolved session id for the current turn
+	 * @param userPrompt latest user prompt (may be empty for handlers that do not require
+	 * one)
 	 */
 	record MemoryFetchContext(AgentCoreLongTermMemoryRetriever retriever, String userId, String sessionId,
 			String userPrompt) {
@@ -175,6 +193,9 @@ public interface MemoryStrategyHandler {
 	 * {@code secondary} is only used by strategies that retrieve two sets under one turn
 	 * (e.g. EPISODIC's reflections). Use {@link #primaryOnly(List)} for single-set
 	 * handlers.
+	 *
+	 * @param primary primary record set
+	 * @param secondary optional secondary record set (e.g. EPISODIC reflections)
 	 */
 	record MemoryFetchResult(List<MemoryRecord> primary, List<MemoryRecord> secondary) {
 

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/SemanticMemoryStrategyHandler.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/SemanticMemoryStrategyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springaicommunity.agentcore.memory.longterm.strategy;
 /**
  * Semantic-search strategy. Fetches facts by semantic similarity against the user prompt
  * and merges them into the system message.
+ *
+ * @author Maximilian Schellhorn
  */
 public final class SemanticMemoryStrategyHandler implements MemoryStrategyHandler {
 

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/SummaryMemoryStrategyHandler.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/SummaryMemoryStrategyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ package org.springaicommunity.agentcore.memory.longterm.strategy;
  * Summary strategy. Retrieves prior-session summaries and augments the user message with
  * them (rather than the system message) so the LLM treats them as grounding for the
  * current question.
+ *
+ * @author Maximilian Schellhorn
  */
 public final class SummaryMemoryStrategyHandler implements MemoryStrategyHandler {
 

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/UserPreferenceMemoryStrategyHandler.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/UserPreferenceMemoryStrategyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springaicommunity.agentcore.memory.longterm.strategy;
 /**
  * User preference strategy. Lists all preferences under the user's namespace without a
  * semantic query, so it does <em>not</em> require a user prompt to run.
+ *
+ * @author Maximilian Schellhorn
  */
 public final class UserPreferenceMemoryStrategyHandler implements MemoryStrategyHandler {
 

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/package-info.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/longterm/strategy/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * built-in long-term memory strategy handlers (semantic, summary, episodic, user
+ * preference).
+ */
+package org.springaicommunity.agentcore.memory.longterm.strategy;

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/package-info.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * spring AI integration with the AgentCore Memory service.
+ */
+package org.springaicommunity.agentcore.memory;

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/AgentCoreShortTermMemoryRepository.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/AgentCoreShortTermMemoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,14 @@ import org.springaicommunity.agentcore.memory.AgentCoreMemoryConversationIdParse
 import org.springaicommunity.agentcore.memory.AgentCoreMemoryException;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.bedrockagentcore.BedrockAgentCoreClient;
-import software.amazon.awssdk.services.bedrockagentcore.model.*;
+import software.amazon.awssdk.services.bedrockagentcore.model.Content;
+import software.amazon.awssdk.services.bedrockagentcore.model.Conversational;
+import software.amazon.awssdk.services.bedrockagentcore.model.CreateEventRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.DeleteEventRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.Event;
+import software.amazon.awssdk.services.bedrockagentcore.model.ListEventsRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.PayloadType;
+import software.amazon.awssdk.services.bedrockagentcore.model.Role;
 
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -56,6 +63,8 @@ import org.springframework.ai.chat.messages.UserMessage;
  * <li>saveAll: Only saves messages without eventId (new messages)</li>
  * <li>After save: Marks saved messages with the returned eventId</li>
  * </ul>
+ *
+ * @author Maximilian Schellhorn
  */
 public class AgentCoreShortTermMemoryRepository implements ChatMemoryRepository {
 
@@ -114,7 +123,8 @@ public class AgentCoreShortTermMemoryRepository implements ChatMemoryRepository 
 							yield null;
 						}
 						else {
-							throw new IllegalStateException("Unsupported role: " + payload.conversational().role());
+							Role role = payload.conversational().role();
+							throw new IllegalStateException("Unsupported role: " + role);
 						}
 					}
 				});
@@ -132,6 +142,9 @@ public class AgentCoreShortTermMemoryRepository implements ChatMemoryRepository 
 
 	/**
 	 * Create AssistantMessage with eventId in metadata for delta tracking.
+	 * @param payload the AgentCore payload
+	 * @param eventId the AgentCore event id, or {@code null} for unsaved messages
+	 * @return assistant message with eventId in its metadata
 	 */
 	private AssistantMessage createAssistantMessage(PayloadType payload, String eventId) {
 		return AssistantMessage.builder()
@@ -142,6 +155,9 @@ public class AgentCoreShortTermMemoryRepository implements ChatMemoryRepository 
 
 	/**
 	 * Create UserMessage with eventId in metadata for delta tracking.
+	 * @param payload the AgentCore payload
+	 * @param eventId the AgentCore event id, or {@code null} for unsaved messages
+	 * @return user message with eventId in its metadata
 	 */
 	private UserMessage createUserMessage(PayloadType payload, String eventId) {
 		return UserMessage.builder()
@@ -288,6 +304,10 @@ public class AgentCoreShortTermMemoryRepository implements ChatMemoryRepository 
 	 * Iterate all events for a conversation page by page. Centralizes pagination so
 	 * callers decide whether to include payloads and whether to honor
 	 * {@link #totalEventsLimit} (retrieval respects the limit; delete must not).
+	 * @param actorAndSession the parsed actor/session pair
+	 * @param includePayloads whether to fetch event payloads
+	 * @param respectLimit whether to honor {@link #totalEventsLimit}
+	 * @param handler callback invoked once per fetched page
 	 */
 	private void forEachEventPage(AgentCoreMemoryConversationIdParser.ActorAndSession actorAndSession,
 			boolean includePayloads, boolean respectLimit, Consumer<List<Event>> handler) {

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/AgentCoreShortTermMemoryRepositoryAutoConfiguration.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/AgentCoreShortTermMemoryRepositoryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/package-info.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * short-term chat memory backed by the AgentCore Memory service.
+ */
+package org.springaicommunity.agentcore.memory.shorttem;

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryConversationIdParserTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryConversationIdParserTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.agentcore.memory;
 
 import org.junit.jupiter.api.Test;

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryE2EIT.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryE2EIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryEnvIT.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryEnvIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryIT.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/EndToEndSpringAIChatClientIntegrationTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/EndToEndSpringAIChatClientIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAdvisorTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAdvisorTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.agentcore.memory.longterm;
 
 import java.util.List;

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAutoConfigurationTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAutoDiscoveryAdvisorFactoryTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryAutoDiscoveryAdvisorFactoryTests.java
@@ -1,13 +1,18 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.springaicommunity.agentcore.memory.longterm;
 
 import java.util.List;

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryNamespaceRegistrarTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryNamespaceRegistrarTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryNamespaceValidatorTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryNamespaceValidatorTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.agentcore.memory.longterm;
 
 import java.util.List;

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryRetrieverTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryRetrieverTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.agentcore.memory.longterm;
 
 import java.util.List;

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryStrategyDiscoveryTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/longterm/AgentCoreLongTermMemoryStrategyDiscoveryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/shortterm/AgentCoreShortTermMemoryAutoConfigurationTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/shortterm/AgentCoreShortTermMemoryAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/shortterm/AgentCoreShortTermMemoryRepositoryConfigurationTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/shortterm/AgentCoreShortTermMemoryRepositoryConfigurationTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.agentcore.memory.shortterm;
 
 import org.junit.jupiter.api.Test;

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/shortterm/AgentCoreShortTermMemoryRepositoryTests.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/shortterm/AgentCoreShortTermMemoryRepositoryTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.agentcore.memory.shortterm;
 
 import java.util.ArrayList;

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/annotation/AgentCoreInvocation.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/annotation/AgentCoreInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import java.lang.annotation.Target;
 /**
  * Marks a method as an agent invocation handler for the AgentCore runtime. Only one
  * method per application can be annotated with this annotation.
+ *
+ * @author Andrei Shakirin
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/annotation/package-info.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/annotation/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * annotations marking AgentCore invocation handlers.
+ */
+package org.springaicommunity.agentcore.annotation;

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreActuatorAutoConfiguration.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreActuatorAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ import org.springframework.context.annotation.Bean;
 /**
  * Auto-configuration for AgentCore Actuator integration. Only loaded when Spring Boot
  * Actuator is on the classpath.
+ *
+ * @author Andrei Shakirin
  */
 @AutoConfiguration
 @ConditionalOnClass(HealthEndpoint.class)
@@ -37,6 +39,7 @@ public class AgentCoreActuatorAutoConfiguration {
 
 	/**
 	 * Provides RequestCounter bean when not already available.
+	 * @return the task tracker bean
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -46,6 +49,9 @@ public class AgentCoreActuatorAutoConfiguration {
 
 	/**
 	 * Provides Actuator-based ping service when Spring Boot Actuator is available.
+	 * @param healthEndpoint the actuator health endpoint
+	 * @param agentCoreTaskTracker the task tracker
+	 * @return the ping service bean
 	 */
 	@Bean
 	@ConditionalOnBean(HealthEndpoint.class)

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreAutoConfiguration.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * Auto-configuration for AgentCore runtime support. Automatically configures all
  * necessary beans when AgentCoreInvocation is on the classpath.
+ *
+ * @author Andrei Shakirin
  */
 @Configuration
 @ConditionalOnClass({ AgentCoreInvocation.class, RestController.class })

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/AgentCorePingAutoConfiguration.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/AgentCorePingAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,12 +26,15 @@ import org.springframework.context.annotation.Bean;
 
 /**
  * Auto-configuration for AgentCore ping services. Provides fallback static ping service.
+ *
+ * @author Andrei Shakirin
  */
 @AutoConfiguration
 public class AgentCorePingAutoConfiguration {
 
 	/**
 	 * Provides RequestCounter bean when not already available.
+	 * @return the task tracker bean
 	 */
 	@Bean
 	@ConditionalOnMissingBean
@@ -41,6 +44,8 @@ public class AgentCorePingAutoConfiguration {
 
 	/**
 	 * Provides a static ping service as fallback when no other ping service is available.
+	 * @param agentCoreTaskTracker the task tracker
+	 * @return the static ping service bean
 	 */
 	@Bean
 	@ConditionalOnMissingBean(AgentCorePingService.class)

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/package-info.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * spring boot auto-configuration for the AgentCore Runtime starter.
+ */
+package org.springaicommunity.agentcore.autoconfigure;

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/context/AgentCoreContext.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/context/AgentCoreContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ import org.springframework.http.HttpHeaders;
  *     return "Processing for session: " + sessionId;
  * }
  * }</pre>
+ *
+ * @author Maximilian Schellhorn
  */
 public class AgentCoreContext {
 

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/context/AgentCoreHeaders.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/context/AgentCoreHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,35 +22,49 @@ package org.springaicommunity.agentcore.context;
  * <p>
  * This class provides constants for headers commonly used in Amazon Bedrock AgentCore
  * requests, organized by functional groups for easy discovery and usage.
+ *
+ * @author Andrei Shakirin
  */
 public final class AgentCoreHeaders {
 
 	// Core AgentCore Headers
+	/** session identifier header. */
 	public static final String SESSION_ID = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id";
 
+	/** user identifier header. */
 	public static final String USER_ID = "X-Amzn-Bedrock-AgentCore-Runtime-User-Id";
 
+	/** prefix for caller-supplied custom headers. */
 	public static final String CUSTOM_HEADER_PREFIX = "X-Amzn-Bedrock-AgentCore-Runtime-Custom-";
 
 	// Authentication & Authorization
+	/** standard HTTP authorization header. */
 	public static final String AUTHORIZATION = "Authorization";
 
+	/** workload access token header. */
 	public static final String WORKLOAD_ACCESS_TOKEN = "workloadaccesstoken";
 
+	/** runtime-specific workload access token header. */
 	public static final String WORKLOAD_ACCESS_TOKEN_RUNTIME = "x-amzn-bedrock-agentcore-runtime-workload-accesstoken";
 
+	/** guest authentication header. */
 	public static final String GUEST_AUTH = "x-aws-guest-auth";
 
 	// AWS Infrastructure
+	/** AWS request id header. */
 	public static final String REQUEST_ID = "x-amzn-requestid";
 
+	/** AWS trace id header. */
 	public static final String TRACE_ID = "x-amzn-trace-id";
 
+	/** w3c baggage propagation header. */
 	public static final String BAGGAGE = "baggage";
 
 	// Proxy Information
+	/** proxy ip header. */
 	public static final String PROXY_IP = "x-aws-proxy-ip";
 
+	/** proxy port header. */
 	public static final String PROXY_PORT = "x-aws-proxy-port";
 
 	private AgentCoreHeaders() {

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/context/package-info.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/context/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * request-scoped AgentCore invocation context and HTTP header constants.
+ */
+package org.springaicommunity.agentcore.context;

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCoreInvocationsController.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCoreInvocationsController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCoreInvocationsHandler.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCoreInvocationsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ package org.springaicommunity.agentcore.controller;
  * Marker interface for AgentCore invocations controllers. Implement this interface to
  * provide custom invocation handling and prevent the auto-configured controller from
  * being created.
+ *
+ * @author Andrei Shakirin
  */
 public interface AgentCoreInvocationsHandler {
 

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCorePingController.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCorePingController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * REST controller implementing the AgentCore /ping health check endpoint.
+ *
+ * @author Maximilian Schellhorn
  */
 @RestController
 public class AgentCorePingController implements AgentCorePingHandler {

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCorePingHandler.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/controller/AgentCorePingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ package org.springaicommunity.agentcore.controller;
  * Marker interface for AgentCore ping controllers. Implement this interface to provide
  * custom ping/health handling and prevent the auto-configured ping controller from being
  * created.
+ *
+ * @author Andrei Shakirin
  */
 public interface AgentCorePingHandler {
 

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/controller/package-info.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/controller/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * REST controllers exposing the AgentCore Runtime contract endpoints.
+ */
+package org.springaicommunity.agentcore.controller;

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/exception/AgentCoreInvocationException.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/exception/AgentCoreInvocationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springaicommunity.agentcore.exception;
 /**
  * Exception thrown when there are issues with AgentCore method invocation, such as
  * multiple methods annotated with @AgentCoreInvocation or unsupported method signatures.
+ *
+ * @author Andrei Shakirin
  */
 public class AgentCoreInvocationException extends RuntimeException {
 

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/exception/package-info.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/exception/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * runtime exceptions raised by the AgentCore Runtime starter.
+ */
+package org.springaicommunity.agentcore.exception;

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/model/AgentCorePingResponse.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/model/AgentCorePingResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.http.HttpStatus;
  * @param status the current status enum (HEALTHY, HEALTHY_BUSY, UNHEALTHY)
  * @param httpStatus the HTTP status code to return with the response
  * @param timeOfLastUpdate timestamp in seconds when the status last changed
+ * @author Andrei Shakirin
  * @since 1.0.0
  */
 public record AgentCorePingResponse(PingStatus status, HttpStatus httpStatus, long timeOfLastUpdate) {

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/model/PingStatus.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/model/PingStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,19 @@
 
 package org.springaicommunity.agentcore.model;
 
+/**
+ * AgentCore Runtime ping status values.
+ *
+ * @author Maximilian Schellhorn
+ */
 public enum PingStatus {
 
-	HEALTHY("Healthy"), HEALTHY_BUSY("HealthyBusy"), UNHEALTHY("Unhealthy");
+	/** ping status when the runtime is idle and ready to accept requests. */
+	HEALTHY("Healthy"),
+	/** ping status when the runtime is processing a long-running task. */
+	HEALTHY_BUSY("HealthyBusy"),
+	/** ping status when the runtime cannot serve traffic. */
+	UNHEALTHY("Unhealthy");
 
 	private final String value;
 

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/model/package-info.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/model/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * model types exchanged on the AgentCore Runtime contract endpoints.
+ */
+package org.springaicommunity.agentcore.model;

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/ping/ActuatorAgentCorePingService.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/ping/ActuatorAgentCorePingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import org.springframework.stereotype.Service;
 
 /**
  * Actuator-based implementation of AgentCorePingService.
+ *
+ * @author Maximilian Schellhorn
  */
 @Service
 public class ActuatorAgentCorePingService implements AgentCorePingService {

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/ping/AgentCorePingService.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/ping/AgentCorePingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springaicommunity.agentcore.model.AgentCorePingResponse;
  * integrate with Spring Boot Actuator for dynamic health checking.
  * </p>
  *
+ * @author Andrei Shakirin
  * @since 1.0.0
  */
 public interface AgentCorePingService {

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/ping/AgentCoreTaskTracker.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/ping/AgentCoreTaskTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,11 @@ import org.springframework.stereotype.Component;
 
 /**
  * AgentCore Task Tracker to report HEALTHY_BUSY status to AgentCore Runtime during health
- * check See:
- * https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-long-run.html
+ * check. See <a href=
+ * "https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-long-run.html">long-running
+ * tasks</a>.
+ *
+ * @author Maximilian Schellhorn
  */
 @Component
 public class AgentCoreTaskTracker {

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/ping/StaticAgentCorePingService.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/ping/StaticAgentCorePingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.stereotype.Service;
  * compatibility with the original AgentCore ping behavior.
  * </p>
  *
+ * @author Maximilian Schellhorn
  * @since 1.0.0
  */
 @Service

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/ping/package-info.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/ping/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * health-check ping support for the AgentCore Runtime contract.
+ */
+package org.springaicommunity.agentcore.ping;

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/service/AgentCoreMethodInvoker.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/service/AgentCoreMethodInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/service/AgentCoreMethodRegistry.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/service/AgentCoreMethodRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import org.springaicommunity.agentcore.exception.AgentCoreInvocationException;
 /**
  * Registry that stores exactly one AgentCore method per application. Enforces the single
  * method constraint for MVP.
+ *
+ * @author Maximilian Schellhorn
  */
 public class AgentCoreMethodRegistry {
 

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/service/AgentCoreMethodScanner.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/service/AgentCoreMethodScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import org.springframework.context.annotation.Lazy;
 /**
  * BeanPostProcessor that scans for @AgentCoreInvocation annotated methods and registers
  * them with the AgentCoreMethodRegistry.
+ *
+ * @author Maximilian Schellhorn
  */
 public class AgentCoreMethodScanner implements BeanPostProcessor {
 

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/service/package-info.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/service/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * service classes that discover and register AgentCore invocation methods.
+ */
+package org.springaicommunity.agentcore.service;

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/RateLimitingFilter.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/RateLimitingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,8 @@ import org.springframework.http.MediaType;
  * part of the public API. Tests that assert on cache size should call
  * {@code buckets.cleanUp()} first so eviction work is applied before reading
  * {@code estimatedSize()}.
+ *
+ * @author Maximilian Schellhorn
  */
 public class RateLimitingFilter implements Filter {
 

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/ThrottleConfiguration.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/ThrottleConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,10 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "agentcore.throttle")
 public class ThrottleConfiguration {
 
+	/** path of the invocations endpoint that is rate limited. */
 	public static final String INVOCATIONS_PATH = "/invocations";
 
+	/** path of the ping endpoint that is rate limited. */
 	public static final String PING_PATH = "/ping";
 
 	private int invocationsLimit;

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/package-info.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/throttle/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * per-client rate limiting filter and configuration for AgentCore endpoints.
+ */
+package org.springaicommunity.agentcore.throttle;

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreAutoConfigurationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreIntegrationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/autoconfigure/AgentCorePingAutoConfigurationComprehensiveTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/autoconfigure/AgentCorePingAutoConfigurationComprehensiveTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/autoconfigure/AgentCorePingAutoConfigurationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/autoconfigure/AgentCorePingAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/context/AgentCoreContextTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/context/AgentCoreContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/controller/AgentCoreInvocationsControllerTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/controller/AgentCoreInvocationsControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/controller/AgentCorePingControllerTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/controller/AgentCorePingControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/exception/AgentCoreInvocationExceptionTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/exception/AgentCoreInvocationExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndContextIntegrationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndContextIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndJsonIntegrationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndJsonIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndStringIntegrationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndStringIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndWebFluxIntegrationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/integration/EndToEndWebFluxIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/ping/ActuatorAgentCorePingServiceStatusMappingTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/ping/ActuatorAgentCorePingServiceStatusMappingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/ping/ActuatorAgentCorePingServiceTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/ping/ActuatorAgentCorePingServiceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/ping/StaticAgentCorePingServiceTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/ping/StaticAgentCorePingServiceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/service/AgentCoreMethodInvokerTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/service/AgentCoreMethodInvokerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/service/AgentCoreMethodRegistryTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/service/AgentCoreMethodRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/service/AgentCoreMethodScannerTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/service/AgentCoreMethodScannerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/RateLimitingFilterBucketCacheTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/RateLimitingFilterBucketCacheTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/RateLimitingFilterDisabledTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/RateLimitingFilterDisabledTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/RateLimitingFilterTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/throttle/RateLimitingFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Add package-info.java for all packages (Spring Checkstyle requirement)
- Add Javadoc to public types, methods, and fields
- Apply Apache 2.0 license headers to files missing them
- Update copyright year from 2025-2025 to 2025-2026

All additive changes — no logic modifications.