### PR TITLE
fix(memory): skip empty-text messages in short-term store

### DIFF
--- a/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/AgentCoreShortTermMemoryRepository.java
+++ b/spring-ai-agentcore-memory/src/main/java/org/springaicommunity/agentcore/memory/shorttem/AgentCoreShortTermMemoryRepository.java
@@ -270,6 +270,11 @@ public class AgentCoreShortTermMemoryRepository implements ChatMemoryRepository 
 			}
 		}
 
+		if (message.getText() == null || message.getText().isBlank()) {
+			logger.debug("Skipping empty-text message for role {}: {}", role, message.getClass().getSimpleName());
+			return null;
+		}
+
 		var content = Content.builder().text(message.getText()).build();
 		var conversational = Conversational.builder().content(content).role(role).build();
 		return PayloadType.builder().conversational(conversational).build();


### PR DESCRIPTION
## Summary
`AgentCoreShortTermMemoryRepository.buildPayloadType` builds `Content.builder().text(message.getText())` unconditionally. An `AssistantMessage` carrying only `tool_calls` has empty text, so it produces a `Conversational` payload with empty `content.text`, which AgentCore `CreateEvent` rejects:

```
ValidationException: Value at 'payload.1.member.conversational.content.text'
failed to satisfy constraint: Member must have length greater than or equal to 1
```

## Fix
Skip messages whose conversational text is blank — return `null`, which `saveAll` already filters via `.filter(Objects::nonNull)`:

```java
if (message.getText() == null || message.getText().isBlank()) {
    logger.debug("Skipping empty-text message for role {}: {}", role, message.getClass().getSimpleName());
    return null;
}
```

An empty conversational turn is never a valid `CreateEvent` payload and carries no dialogue value (the tool-call assistant turn's user-facing text is the *final* assistant message, which has content).

## Why it surfaces now (M6 worked)
Same SDK `1.0.0`; only the Spring AI version differs:
- **M6:** `BedrockProxyChatModel` executed tools **internally** — the tool-call/tool-response exchange stayed inside the model and never reached the advisor chain, so only user + final-assistant messages were persisted.
- **M7+:** internal tool execution is deprecated (*"Internal tool execution in BedrockProxyChatModel is deprecated since 2.0.0 … Use ChatClient with ToolCallAdvisor instead."*); tool calling runs at the ChatClient/advisor layer, so `MessageChatMemoryAdvisor.before()` now routes the empty-text tool-call `AssistantMessage` into the short-term store.

## Testing
- `mvn -pl spring-ai-agentcore-memory -am compile` + checkstyle/spring-javaformat/license: pass.
- Full local test run is blocked by a CrowdStrike Falcon record class-drop on this machine (intermittent `cannot find symbol` on record `.class` files); relying on CI for the test suite.

Fixes #110
