### PR TITLE
Add observability example and OTel extension for AgentCore Runtime

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -25,6 +25,7 @@
 
     <modules>
         <module>simple-spring-boot-app</module>
+        <module>spring-ai-agentcore-observability</module>
         <module>spring-ai-browser</module>
         <module>spring-ai-extended-chat-client</module>
         <module>spring-ai-memory-integration</module>

--- a/examples/spring-ai-agentcore-observability/.gitignore
+++ b/examples/spring-ai-agentcore-observability/.gitignore
@@ -1,0 +1,24 @@
+# Maven
+target/
+
+# Terraform
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup
+terraform/terraform.tfvars
+terraform/*.tfplan
+terraform/tfplan
+terraform/image-uri.txt
+terraform/ecr-repo-name.txt
+
+# IDE
+.idea/
+*.iml
+.vscode/
+
+# OS
+.DS_Store
+
+# Logs
+*.log

--- a/examples/spring-ai-agentcore-observability/Dockerfile
+++ b/examples/spring-ai-agentcore-observability/Dockerfile
@@ -2,8 +2,11 @@ FROM --platform=linux/arm64 amazoncorretto:21-alpine
 
 # AWS Distro for OpenTelemetry (ADOT) Java auto-instrumentation agent version.
 ARG ADOT_VERSION=v2.26.2
-# AgentCore OTel extension version (adds aws.service.type=gen_ai_agent for the GenAI dashboard).
+# AgentCore OTel extension version. Recorded as a Docker LABEL on the image below.
 ARG AGENTCORE_EXT_VERSION=1.1.0
+
+LABEL org.springaicommunity.agentcore-ext-version="${AGENTCORE_EXT_VERSION}" \
+      org.springaicommunity.adot-version="${ADOT_VERSION}"
 
 RUN addgroup -S appuser && adduser -S appuser -G appuser
 WORKDIR /app

--- a/examples/spring-ai-agentcore-observability/Dockerfile
+++ b/examples/spring-ai-agentcore-observability/Dockerfile
@@ -1,0 +1,37 @@
+FROM --platform=linux/arm64 amazoncorretto:21-alpine
+
+# AWS Distro for OpenTelemetry (ADOT) Java auto-instrumentation agent version.
+ARG ADOT_VERSION=v2.26.2
+# AgentCore OTel extension version (adds aws.service.type=gen_ai_agent for the GenAI dashboard).
+ARG AGENTCORE_EXT_VERSION=1.1.0
+
+RUN addgroup -S appuser && adduser -S appuser -G appuser
+WORKDIR /app
+
+# The ADOT Java agent auto-instruments Spring MVC and ships spans to the CloudWatch
+# X-Ray OTLP endpoint with SigV4 signing (collector-less). It also forwards the
+# Micrometer-bridged Spring AI spans.
+RUN apk add --no-cache curl \
+    && curl -fsSL -o /app/aws-opentelemetry-agent.jar \
+       "https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/${ADOT_VERSION}/aws-opentelemetry-agent.jar" \
+    && apk del curl
+
+COPY target/agentcore-otel-extension.jar /app/agentcore-otel-extension.jar
+
+COPY target/spring-ai-agentcore-observability.jar app.jar
+RUN chown -R appuser:appuser /app
+USER appuser
+EXPOSE 8080
+
+# Attach the ADOT agent and the AgentCore OTel extension. The extension handles agent
+# observability mode config (resource attributes, session tracking, noise reduction) when
+# AGENT_OBSERVABILITY_ENABLED=true is injected by AgentCore. Only exporter plumbing remains
+# here. OTEL_RESOURCE_ATTRIBUTES is NOT set — AgentCore injects it with cloud.resource_id.
+ENV JAVA_TOOL_OPTIONS="-javaagent:/app/aws-opentelemetry-agent.jar" \
+    OTEL_JAVAAGENT_EXTENSIONS=/app/agentcore-otel-extension.jar \
+    OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+    OTEL_TRACES_EXPORTER=otlp \
+    OTEL_METRICS_EXPORTER=none \
+    OTEL_LOGS_EXPORTER=none
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/examples/spring-ai-agentcore-observability/Dockerfile
+++ b/examples/spring-ai-agentcore-observability/Dockerfile
@@ -23,14 +23,11 @@ RUN chown -R appuser:appuser /app
 USER appuser
 EXPOSE 8080
 
-# Attach the ADOT agent and the AgentCore OTel extension. The extension handles agent
-# observability mode config (resource attributes, session tracking, noise reduction) when
-# AGENT_OBSERVABILITY_ENABLED=true is injected by AgentCore. Only exporter plumbing remains
-# here. OTEL_RESOURCE_ATTRIBUTES is NOT set — AgentCore injects it with cloud.resource_id.
+# Attach the ADOT agent and the AgentCore OTel extension. The extension handles all
+# observability config (exporters, protocol, sampler, resource attributes, noise
+# reduction) when AGENT_OBSERVABILITY_ENABLED=true is injected by AgentCore.
+# OTEL_RESOURCE_ATTRIBUTES is NOT set — AgentCore injects it with cloud.resource_id.
 ENV JAVA_TOOL_OPTIONS="-javaagent:/app/aws-opentelemetry-agent.jar" \
-    OTEL_JAVAAGENT_EXTENSIONS=/app/agentcore-otel-extension.jar \
-    OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
-    OTEL_TRACES_EXPORTER=otlp \
-    OTEL_LOGS_EXPORTER=otlp
+    OTEL_JAVAAGENT_EXTENSIONS=/app/agentcore-otel-extension.jar
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/examples/spring-ai-agentcore-observability/Dockerfile
+++ b/examples/spring-ai-agentcore-observability/Dockerfile
@@ -31,7 +31,6 @@ ENV JAVA_TOOL_OPTIONS="-javaagent:/app/aws-opentelemetry-agent.jar" \
     OTEL_JAVAAGENT_EXTENSIONS=/app/agentcore-otel-extension.jar \
     OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
     OTEL_TRACES_EXPORTER=otlp \
-    OTEL_METRICS_EXPORTER=none \
     OTEL_LOGS_EXPORTER=none
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/examples/spring-ai-agentcore-observability/Dockerfile
+++ b/examples/spring-ai-agentcore-observability/Dockerfile
@@ -31,6 +31,6 @@ ENV JAVA_TOOL_OPTIONS="-javaagent:/app/aws-opentelemetry-agent.jar" \
     OTEL_JAVAAGENT_EXTENSIONS=/app/agentcore-otel-extension.jar \
     OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
     OTEL_TRACES_EXPORTER=otlp \
-    OTEL_LOGS_EXPORTER=none
+    OTEL_LOGS_EXPORTER=otlp
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/examples/spring-ai-agentcore-observability/README.md
+++ b/examples/spring-ai-agentcore-observability/README.md
@@ -1,0 +1,138 @@
+# Spring AI AgentCore Observability
+
+A Spring AI + Amazon Bedrock agent running on **AgentCore Runtime** with full
+**OpenTelemetry observability** in the CloudWatch GenAI Observability dashboard.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  client["Client"] -->|"invoke-agent-runtime"| app
+
+  subgraph runtime["AgentCore Runtime (linux/arm64)"]
+    app["Spring Boot + Spring AI"]
+    agent["ADOT Java agent + AgentCore extension"]
+    app -. "Micrometer → OTel bridge" .-> agent
+  end
+
+  app -->|"Bedrock Converse"| bedrock[("Amazon Bedrock")]
+  agent -->|"OTLP traces (SigV4)"| xray["X-Ray OTLP endpoint"]
+  app -->|"stdout"| logs["default runtime log group"]
+  xray --> dash["GenAI Observability dashboard"]
+```
+
+**How it works:**
+
+- The **ADOT Java agent** auto-instruments the app and exports traces (SigV4-signed) to CloudWatch.
+- The **AgentCore OTel extension** (`spring-ai-agentcore-otel-extension`) configures the agent for
+  AgentCore's observability mode — adding the required resource attributes, session tracking, and
+  noise reduction. It activates when `AGENT_OBSERVABILITY_ENABLED=true` (injected by AgentCore).
+- **Spring AI** observations (ChatClient, model calls, tool invocations) are bridged into the same
+  trace via `micrometer-tracing-bridge-otel`.
+- **Logs** go to stdout → captured by AgentCore into the default runtime log group.
+- **`OTEL_RESOURCE_ATTRIBUTES`** is injected by AgentCore at container start (with `cloud.resource_id`,
+  `cloud.platform`, `service.name`). Do **not** override it — that breaks dashboard linkage.
+
+## What you see in the dashboard
+
+| Signal | Source |
+|--------|--------|
+| ChatClient / advisor / tool spans | Spring AI Micrometer observations |
+| Bedrock model span + token usage | Spring AI + ADOT aws-sdk instrumentation |
+| `POST /invocations` server span | Spring MVC observation |
+| Session grouping | `session.id` propagated from baggage by the extension |
+| Application logs | container stdout → default runtime log group |
+
+### Example trace
+
+```mermaid
+flowchart TB
+  s["POST /invocations"] --> cc["spring_ai chat_client"]
+  cc --> adv["call — advisor"]
+  adv --> m1["chat model (Spring AI, tokens)"]
+  m1 --> sdk1["chat model (aws-sdk-2.2)"]
+  adv --> t["tool_call get-current-date-time"]
+  adv --> m2["chat model (2nd call)"]
+  m2 --> sdk2["chat model (aws-sdk-2.2)"]
+```
+
+## Prerequisites
+
+- Java 21, Maven, Terraform, AWS CLI
+- **Docker or Finch** (set `CONTAINER_CLI`; default `docker`). Image is `linux/arm64`.
+- AWS credentials with Bedrock model access.
+
+## One-time setup: enable CloudWatch Transaction Search
+
+Required once per account/region:
+
+```bash
+aws logs put-resource-policy \
+  --policy-name TransactionSearchAccess \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Sid":"TransactionSearchXRayAccess","Effect":"Allow","Principal":{"Service":"xray.amazonaws.com"},"Action":"logs:PutLogEvents","Resource":["arn:aws:logs:*:*:log-group:aws/spans:*","arn:aws:logs:*:*:log-group:/aws/application-signals/data:*"]}]}'
+
+aws xray update-trace-segment-destination --destination CloudWatchLogs
+```
+
+Or: CloudWatch console → **Application Signals (APM) → Transaction search → Enable**.
+
+## Deploy
+
+```bash
+./build-and-push.sh                       # build + push image to ECR
+./deploy.sh                               # terraform: IAM role + AgentCore runtime
+./invoke.sh                               # invoke (triggers the tool, generates a trace)
+./invoke.sh "my-session-33chars-minimum" "Your prompt here"
+```
+
+## View telemetry
+
+- **Traces**: CloudWatch → **GenAI Observability** → **Bedrock AgentCore** tab
+- **Logs**: default runtime log group (`/aws/bedrock-agentcore/runtimes/<runtime-id>-DEFAULT`)
+- **Raw spans**: Transaction Search / `aws/spans` log group
+
+Allow ~10 minutes after first invocation for spans to appear.
+
+## The AgentCore OTel Extension
+
+The `spring-ai-agentcore-otel-extension` jar bridges the observability gap between Python and Java
+on AgentCore Runtime. It's activated by `AGENT_OBSERVABILITY_ENABLED=true` (injected by AgentCore)
+and provides:
+
+| Feature | Why |
+|---------|-----|
+| `aws.service.type=gen_ai_agent` resource attribute | Required for the "Bedrock AgentCore" dashboard tab |
+| `session.id` baggage → span attribute | Groups traces by session in the dashboard |
+| `parentbased_always_on` sampler | 100% span capture for agent observability |
+| Disable AWS resource detectors | Prevents `cloud.platform=aws_ec2` from overriding AgentCore's value |
+| Disable Application Signals | Avoids duplicate cost with Transaction Search |
+| Disable `http-url-connection` + Tomcat/Servlet instrumentation | Suppresses IMDS noise and duplicate server spans |
+
+**Usage in your Dockerfile:**
+
+```dockerfile
+ARG AGENTCORE_EXT_VERSION=1.1.0
+RUN curl -fsSL -o /app/agentcore-otel-extension.jar \
+    "https://repo1.maven.org/maven2/org/springaicommunity/spring-ai-agentcore-otel-extension/${AGENTCORE_EXT_VERSION}/spring-ai-agentcore-otel-extension-${AGENTCORE_EXT_VERSION}.jar"
+
+ENV OTEL_JAVAAGENT_EXTENSIONS=/app/agentcore-otel-extension.jar
+```
+
+All settings are defaults — override any with environment variables if needed.
+
+## Configuration
+
+| Setting | Where | Default |
+|---------|-------|---------|
+| Model | `application.properties` | `global.amazon.nova-2-lite-v1:0` |
+| Trace endpoint | Terraform env var | `https://xray.<region>.amazonaws.com/v1/traces` |
+| Sampling | `application.properties` | `1.0` (100%) |
+| Prompt/completion logging | `application.properties` | disabled (sensitive) |
+| ADOT agent version | `Dockerfile` `ADOT_VERSION` | `v2.26.2` |
+
+## Cleanup
+
+```bash
+cd terraform && terraform destroy
+aws ecr delete-repository --repository-name "$(cat terraform/ecr-repo-name.txt)" --force
+```

--- a/examples/spring-ai-agentcore-observability/build-and-push.sh
+++ b/examples/spring-ai-agentcore-observability/build-and-push.sh
@@ -31,6 +31,13 @@ aws ecr get-login-password --region "${REGION}" | "${CONTAINER_CLI}" login --use
 echo "🔨 Building Spring Boot application..."
 mvn -q clean package
 
+echo "📦 Copying AgentCore OTel extension jar..."
+# For SNAPSHOT builds, copy the extension jar from the local build output.
+# For releases, replace this with:
+#   curl -fsSL -o target/agentcore-otel-extension.jar \
+#     "https://repo1.maven.org/maven2/org/springaicommunity/spring-ai-agentcore-otel-extension/${VERSION}/spring-ai-agentcore-otel-extension-${VERSION}.jar"
+cp ../../spring-ai-agentcore-otel-extension/target/spring-ai-agentcore-otel-extension-*-SNAPSHOT.jar target/agentcore-otel-extension.jar
+
 echo "🐳 Building container image (linux/arm64)..."
 "${CONTAINER_CLI}" build --platform linux/arm64 -t "${ECR_REPO_NAME}" .
 "${CONTAINER_CLI}" tag "${ECR_REPO_NAME}:latest" "${IMAGE_URI}"

--- a/examples/spring-ai-agentcore-observability/build-and-push.sh
+++ b/examples/spring-ai-agentcore-observability/build-and-push.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+echo "🚀 Building and pushing Spring AI AgentCore Observability example"
+
+# Container runtime (docker by default; set CONTAINER_CLI=finch to use Finch).
+CONTAINER_CLI="${CONTAINER_CLI:-docker}"
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REGION=$(aws configure get region || echo "us-east-1")
+
+SUFFIX=$(openssl rand -hex 4)
+ECR_REPO_NAME="spring-ai-agentcore-observability-${SUFFIX}"
+IMAGE_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${ECR_REPO_NAME}:latest"
+
+echo "📦 ECR Repository: ${ECR_REPO_NAME}"
+echo "🏷️  Image URI: ${IMAGE_URI}"
+echo "🧰 Container CLI: ${CONTAINER_CLI}"
+
+if ! aws ecr describe-repositories --repository-names "${ECR_REPO_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+    echo "📦 Creating ECR repository..."
+    aws ecr create-repository \
+        --repository-name "${ECR_REPO_NAME}" \
+        --region "${REGION}" \
+        --image-scanning-configuration scanOnPush=true >/dev/null
+fi
+
+echo "🔐 Logging into ECR..."
+aws ecr get-login-password --region "${REGION}" | "${CONTAINER_CLI}" login --username AWS --password-stdin "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+
+echo "🔨 Building Spring Boot application..."
+mvn -q clean package
+
+echo "🐳 Building container image (linux/arm64)..."
+"${CONTAINER_CLI}" build --platform linux/arm64 -t "${ECR_REPO_NAME}" .
+"${CONTAINER_CLI}" tag "${ECR_REPO_NAME}:latest" "${IMAGE_URI}"
+
+echo "📤 Pushing image to ECR..."
+"${CONTAINER_CLI}" push "${IMAGE_URI}"
+
+mkdir -p terraform
+echo "${IMAGE_URI}" > terraform/image-uri.txt
+echo "${ECR_REPO_NAME}" > terraform/ecr-repo-name.txt
+
+echo "✅ Build and push completed. Image URI saved to terraform/image-uri.txt"

--- a/examples/spring-ai-agentcore-observability/deploy.sh
+++ b/examples/spring-ai-agentcore-observability/deploy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+echo "🚀 Deploying Spring AI AgentCore Observability example"
+
+for tool in terraform "${CONTAINER_CLI:-docker}" aws; do
+    if ! command -v "$tool" &> /dev/null; then
+        echo "❌ $tool is required but not installed"
+        exit 1
+    fi
+done
+
+if ! aws sts get-caller-identity &> /dev/null; then
+    echo "❌ AWS credentials not configured"
+    exit 1
+fi
+
+if [ ! -f terraform/image-uri.txt ]; then
+    echo "❌ terraform/image-uri.txt not found. Run ./build-and-push.sh first."
+    exit 1
+fi
+
+cd terraform
+
+echo "🔧 Initializing Terraform..."
+terraform init -input=false
+
+echo "📋 Planning deployment..."
+terraform plan -out=tfplan
+
+echo "🚀 Applying..."
+terraform apply -auto-approve tfplan
+
+echo ""
+echo "✅ Deployment complete!"
+echo "  Runtime ARN:   $(terraform output -raw runtime_arn)"
+echo ""
+echo "🔍 Invoke with: ./invoke.sh"
+echo "📊 View traces: CloudWatch console → GenAI Observability → Bedrock AgentCore"

--- a/examples/spring-ai-agentcore-observability/invoke.sh
+++ b/examples/spring-ai-agentcore-observability/invoke.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+AWS_REGION="${AWS_REGION:-$(cd terraform && terraform output -raw region 2>/dev/null || echo us-east-1)}"
+# Runtime session IDs must be at least 33 characters. The agent propagates this as the
+# session.id on the emitted spans, so traces for the same session group together.
+SESSION_ID="${1:-obs-session-$(date +%s)abcdefghijklmnopqrstuvwxyz}"
+PROMPT="${2:-What is the current date and time?}"
+
+AGENT_RUNTIME_ARN=$(cd terraform && terraform output -raw runtime_arn 2>/dev/null)
+if [ -z "$AGENT_RUNTIME_ARN" ]; then
+    echo "❌ No runtime found. Run ./deploy.sh first."
+    exit 1
+fi
+
+if [ ${#SESSION_ID} -lt 33 ]; then
+    echo "❌ Session ID must be at least 33 characters (got ${#SESSION_ID})"
+    exit 1
+fi
+
+echo "🚀 Invoking runtime"
+echo "📝 Prompt: $PROMPT"
+echo "🔑 Session ID: $SESSION_ID"
+echo ""
+
+PAYLOAD_B64=$(printf '{"prompt":"%s"}' "$PROMPT" | base64)
+
+aws bedrock-agentcore invoke-agent-runtime \
+    --agent-runtime-arn "$AGENT_RUNTIME_ARN" \
+    --content-type "application/json" \
+    --accept "application/json" \
+    --runtime-session-id "$SESSION_ID" \
+    --runtime-user-id "obs-user" \
+    --qualifier "DEFAULT" \
+    --payload "$PAYLOAD_B64" \
+    --region "$AWS_REGION" \
+    --no-cli-pager \
+    --output text \
+    --query 'response' \
+    /dev/stdout
+echo ""
+echo "✅ Invocation completed"

--- a/examples/spring-ai-agentcore-observability/pom.xml
+++ b/examples/spring-ai-agentcore-observability/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springaicommunity.examples</groupId>
+        <artifactId>spring-ai-agentcore-examples</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-ai-agentcore-observability</artifactId>
+    <name>Spring AI AgentCore Observability</name>
+    <description>Spring AI + Bedrock agent on AgentCore Runtime with end-to-end OpenTelemetry observability</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-agentcore-runtime-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-agentcore-memory</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <!-- Actuator enables Spring AI's Micrometer observations (ChatClient/ChatModel/tool spans + token usage) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <!-- Bridges Micrometer observations to OpenTelemetry spans; export is handled by the ADOT Java agent -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/DateTimeTools.java
+++ b/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/DateTimeTools.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.example.observability;
+
+import java.time.LocalDateTime;
+
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.context.i18n.LocaleContextHolder;
+
+class DateTimeTools {
+
+	@Tool(description = "Get the current date and time in the user's timezone")
+	String getCurrentDateTime() {
+		return LocalDateTime.now().atZone(LocaleContextHolder.getTimeZone().toZoneId()).toString();
+	}
+
+}

--- a/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/ObservabilityApplication.java
+++ b/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/ObservabilityApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.example.observability;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ObservabilityApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ObservabilityApplication.class, args);
+	}
+
+}

--- a/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/ObservabilityChatController.java
+++ b/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/ObservabilityChatController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.example.observability;
+
+import java.util.Map;
+
+import org.springaicommunity.agentcore.annotation.AgentCoreInvocation;
+import org.springaicommunity.agentcore.context.AgentCoreContext;
+import org.springaicommunity.agentcore.context.AgentCoreHeaders;
+import org.springaicommunity.agentcore.memory.shorttem.AgentCoreShortTermMemoryRepository;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Spring AI agent with short-term memory. Uses the AgentCore session ID as the
+ * conversation ID, so memory persists across invocations within the same session.
+ *
+ * @author Maximilian Schellhorn
+ */
+@Service
+public class ObservabilityChatController {
+
+	private final ChatClient chatClient;
+
+	private final ChatMemory chatMemory;
+
+	public ObservabilityChatController(ChatClient.Builder chatClientBuilder,
+			AgentCoreShortTermMemoryRepository memoryRepository) {
+		this.chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(memoryRepository)
+			.maxMessages(20)
+			.build();
+		this.chatClient = chatClientBuilder.defaultTools(new DateTimeTools()).build();
+	}
+
+	@AgentCoreInvocation
+	public Map<String, Object> chat(Map<String, Object> request, AgentCoreContext context) {
+		String prompt = String.valueOf(request.getOrDefault("prompt", ""));
+		String sessionId = context.getHeader(AgentCoreHeaders.SESSION_ID);
+		String conversationId = (sessionId != null && !sessionId.isEmpty()) ? sessionId : "default";
+
+		String response = this.chatClient.prompt()
+			.user(prompt)
+			.advisors(MessageChatMemoryAdvisor.builder(this.chatMemory).build())
+			.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, conversationId))
+			.call()
+			.content();
+
+		return Map.of("response", response);
+	}
+
+}

--- a/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/ObservabilityChatController.java
+++ b/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/ObservabilityChatController.java
@@ -18,6 +18,9 @@ package org.springaicommunity.example.observability;
 
 import java.util.Map;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
 import org.springaicommunity.agentcore.annotation.AgentCoreInvocation;
 import org.springaicommunity.agentcore.context.AgentCoreContext;
 import org.springaicommunity.agentcore.context.AgentCoreHeaders;
@@ -42,13 +45,19 @@ public class ObservabilityChatController {
 
 	private final ChatMemory chatMemory;
 
+	private final Counter invocationCounter;
+
 	public ObservabilityChatController(ChatClient.Builder chatClientBuilder,
-			AgentCoreShortTermMemoryRepository memoryRepository) {
+			AgentCoreShortTermMemoryRepository memoryRepository, MeterRegistry meterRegistry) {
 		this.chatMemory = MessageWindowChatMemory.builder()
 			.chatMemoryRepository(memoryRepository)
 			.maxMessages(20)
 			.build();
 		this.chatClient = chatClientBuilder.defaultTools(new DateTimeTools()).build();
+		this.invocationCounter = Counter.builder("custom.agent.invocations")
+			.description("Number of agent invocations")
+			.tag("agent", "observability-demo")
+			.register(meterRegistry);
 	}
 
 	@AgentCoreInvocation
@@ -56,6 +65,8 @@ public class ObservabilityChatController {
 		String prompt = String.valueOf(request.getOrDefault("prompt", ""));
 		String sessionId = context.getHeader(AgentCoreHeaders.SESSION_ID);
 		String conversationId = (sessionId != null && !sessionId.isEmpty()) ? sessionId : "default";
+
+		this.invocationCounter.increment();
 
 		String response = this.chatClient.prompt()
 			.user(prompt)

--- a/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/ObservabilityChatController.java
+++ b/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/ObservabilityChatController.java
@@ -24,7 +24,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import org.springaicommunity.agentcore.annotation.AgentCoreInvocation;
 import org.springaicommunity.agentcore.context.AgentCoreContext;
 import org.springaicommunity.agentcore.context.AgentCoreHeaders;
-import org.springaicommunity.agentcore.memory.shorttem.AgentCoreShortTermMemoryRepository;
+import org.springaicommunity.agentcore.memory.shortterm.AgentCoreShortTermMemoryRepository;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;

--- a/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/OpenTelemetryConfig.java
+++ b/examples/spring-ai-agentcore-observability/src/main/java/org/springaicommunity/example/observability/OpenTelemetryConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.example.observability;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Bridges Spring Boot's tracing autoconfiguration to the ADOT Java agent's OpenTelemetry
+ * SDK. Without this, Spring Boot's {@code OpenTelemetryAutoConfiguration} creates its own
+ * separate {@code SdkOpenTelemetry} bean that the Micrometer Tracing bridge uses; spans
+ * created from Spring AI observations (ChatClient, advisor, ChatModel, tool) end up in
+ * that separate SDK and never reach X-Ray. By exposing {@link GlobalOpenTelemetry#get()}
+ * as the primary {@code OpenTelemetry} bean, the bridge writes to the same SDK the agent
+ * uses for AWS SDK auto-instrumentation, so the full span tree appears in the GenAI
+ * Observability dashboard.
+ *
+ * <p>
+ * The agent must be attached for this to work: it installs its SDK as
+ * {@code GlobalOpenTelemetry} during JVM startup, before this bean is resolved.
+ */
+@Configuration
+class OpenTelemetryConfig {
+
+	@Bean
+	OpenTelemetry openTelemetry() {
+		return GlobalOpenTelemetry.get();
+	}
+
+}

--- a/examples/spring-ai-agentcore-observability/src/main/resources/application.properties
+++ b/examples/spring-ai-agentcore-observability/src/main/resources/application.properties
@@ -1,0 +1,24 @@
+spring.application.name=spring-ai-agentcore-observability
+spring.ai.bedrock.converse.chat.options.model=global.amazon.nova-2-lite-v1:0
+
+# Inference params Bedrock Converse supports; each surfaces as a gen_ai.request.* span attribute.
+# (topK, frequencyPenalty and presencePenalty are ignored by BedrockProxyChatModel, so omitted.)
+spring.ai.bedrock.converse.chat.options.temperature=0.7
+spring.ai.bedrock.converse.chat.options.top-p=0.9
+spring.ai.bedrock.converse.chat.options.max-tokens=512
+spring.ai.bedrock.converse.chat.options.stop-sequences=###STOP###
+
+server.port=8080
+
+# AgentCore Memory (short-term)
+agentcore.memory.memory-id=${AGENTCORE_MEMORY_ID:}
+
+# Actuator powers the AgentCore /ping health check and enables Spring AI's Micrometer observations.
+management.endpoints.web.exposure.include=health
+management.tracing.sampling.probability=1.0
+
+# Prompt and completion content is NOT exported by default (it may contain sensitive data).
+# Enable the following only for debugging:
+# spring.ai.chat.client.observations.log-prompt=true
+# spring.ai.chat.observations.log-prompt=true
+# spring.ai.chat.observations.log-completion=true

--- a/examples/spring-ai-agentcore-observability/src/main/resources/application.properties
+++ b/examples/spring-ai-agentcore-observability/src/main/resources/application.properties
@@ -15,6 +15,11 @@ agentcore.memory.memory-id=${AGENTCORE_MEMORY_ID:}
 
 # Actuator powers the AgentCore /ping health check and enables Spring AI's Micrometer observations.
 management.endpoints.web.exposure.include=health
+# Spring's auto-configured Sampler bean is unused: OpenTelemetryConfig replaces the
+# OpenTelemetry bean with the ADOT agent's GlobalOpenTelemetry, whose own SdkTracerProvider
+# is what samples spans. Effective sampling is controlled by otel.traces.sampler
+# (set to parentbased_always_on by the AgentCore OTel extension). This property is kept
+# as a hint to readers that 100% sampling is intended; changing it has no effect.
 management.tracing.sampling.probability=1.0
 
 # Prompt and completion content is NOT exported by default (it may contain sensitive data).

--- a/examples/spring-ai-agentcore-observability/src/main/resources/application.properties
+++ b/examples/spring-ai-agentcore-observability/src/main/resources/application.properties
@@ -22,3 +22,20 @@ management.tracing.sampling.probability=1.0
 # spring.ai.chat.client.observations.log-prompt=true
 # spring.ai.chat.observations.log-prompt=true
 # spring.ai.chat.observations.log-completion=true
+
+# --- EMF Metrics (custom business metrics → CloudWatch via ADOT agent) ---
+# Enable the OTel Micrometer bridge so custom MeterRegistry counters/gauges/timers are
+# exported as CloudWatch metrics via the EMF exporter.
+#
+# Already covered WITHOUT the Micrometer bridge (always exported by the ADOT agent):
+#   - gen_ai.client.token.usage (input/output tokens per model call)
+#   - gen_ai.client.operation.duration (model call latency histogram)
+#   - jvm.* (memory, GC, threads, CPU — from JMX instrumentation)
+#
+# Already covered by spans (GenAI Observability dashboard derives metrics from traces):
+#   - spring.ai.chat.client, spring.ai.advisor, spring.ai.tool (span durations)
+#   - http.server.requests (POST /invocations server span)
+#
+# Only custom business metrics need the Micrometer bridge. Use the "custom." prefix.
+otel.instrumentation.micrometer.enabled=true
+otel.instrumentation.micrometer.metric-names.include=custom.*

--- a/examples/spring-ai-agentcore-observability/src/main/resources/application.properties
+++ b/examples/spring-ai-agentcore-observability/src/main/resources/application.properties
@@ -36,6 +36,7 @@ management.tracing.sampling.probability=1.0
 #   - spring.ai.chat.client, spring.ai.advisor, spring.ai.tool (span durations)
 #   - http.server.requests (POST /invocations server span)
 #
-# Only custom business metrics need the Micrometer bridge. Use the "custom." prefix.
+# Only custom business metrics and cold-start timing need the Micrometer bridge.
+# Use the "custom." prefix for app-specific metrics.
 otel.instrumentation.micrometer.enabled=true
-otel.instrumentation.micrometer.metric-names.include=custom.*
+otel.instrumentation.micrometer.metric-names.include=custom.*,application.ready.time,application.started.time

--- a/examples/spring-ai-agentcore-observability/terraform/main.tf
+++ b/examples/spring-ai-agentcore-observability/terraform/main.tf
@@ -82,13 +82,6 @@ resource "aws_iam_role_policy" "agentcore_execution" {
   })
 }
 
-# Log group for OTLP logs and EMF metrics. The OTLP CW Logs endpoint requires
-# the log group to exist before sending logs (unlike PutLogEvents which auto-creates).
-resource "aws_cloudwatch_log_group" "agent_logs" {
-  name              = "/aws/bedrock-agentcore/runtimes/${local.runtime_name}"
-  retention_in_days = 7
-}
-
 # Short-term memory for session-scoped conversation history.
 resource "aws_bedrockagentcore_memory" "stm" {
   name                 = "observability_stm_${random_string.suffix.result}"
@@ -111,11 +104,10 @@ resource "aws_bedrockagentcore_agent_runtime" "observability" {
     network_mode = "PUBLIC"
   }
 
-  # Observability configuration. The OTel extension auto-derives the traces and logs
-  # OTLP endpoints from AWS_REGION (injected by AgentCore). Only the log headers
-  # need to be set explicitly to specify the target log group for logs + EMF metrics.
+  # AgentCore injects OTEL_EXPORTER_OTLP_LOGS_HEADERS (with log group/stream/namespace)
+  # and OTEL_RESOURCE_ATTRIBUTES automatically. The extension overrides the endpoints
+  # from localhost:4316 (Python sidecar) to the direct AWS OTLP endpoints via SigV4.
   environment_variables = {
-    OTEL_EXPORTER_OTLP_LOGS_HEADERS = "x-aws-log-group=${aws_cloudwatch_log_group.agent_logs.name},x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore"
-    AGENTCORE_MEMORY_ID             = aws_bedrockagentcore_memory.stm.id
+    AGENTCORE_MEMORY_ID = aws_bedrockagentcore_memory.stm.id
   }
 }

--- a/examples/spring-ai-agentcore-observability/terraform/main.tf
+++ b/examples/spring-ai-agentcore-observability/terraform/main.tf
@@ -111,20 +111,11 @@ resource "aws_bedrockagentcore_agent_runtime" "observability" {
     network_mode = "PUBLIC"
   }
 
-  # Observability configuration following the AgentCore docs pattern:
-  # - Traces: OTLP → X-Ray endpoint (SigV4, collector-less)
-  # - Logs: OTLP → CloudWatch Logs endpoint (SigV4, structured with trace correlation)
-  # - Metrics: EMF via PutLogEvents to the same log group (ADOT agent's awsemf exporter)
-  #
-  # OTEL_EXPORTER_OTLP_LOGS_HEADERS serves dual purpose: it configures both the OTLP
-  # logs exporter (target log group/stream) and the EMF metrics exporter (namespace).
-  # OTEL_RESOURCE_ATTRIBUTES is intentionally NOT set — AgentCore injects it with
-  # cloud.resource_id + cloud.platform, which links spans to this runtime in the
-  # GenAI Observability dashboard.
+  # Observability configuration. The OTel extension auto-derives the traces and logs
+  # OTLP endpoints from AWS_REGION (injected by AgentCore). Only the log headers
+  # need to be set explicitly to specify the target log group for logs + EMF metrics.
   environment_variables = {
-    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "https://xray.${var.aws_region}.amazonaws.com/v1/traces"
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT   = "https://logs.${var.aws_region}.amazonaws.com/v1/logs"
-    OTEL_EXPORTER_OTLP_LOGS_HEADERS    = "x-aws-log-group=${aws_cloudwatch_log_group.agent_logs.name},x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore"
-    AGENTCORE_MEMORY_ID                = aws_bedrockagentcore_memory.stm.id
+    OTEL_EXPORTER_OTLP_LOGS_HEADERS = "x-aws-log-group=${aws_cloudwatch_log_group.agent_logs.name},x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore"
+    AGENTCORE_MEMORY_ID             = aws_bedrockagentcore_memory.stm.id
   }
 }

--- a/examples/spring-ai-agentcore-observability/terraform/main.tf
+++ b/examples/spring-ai-agentcore-observability/terraform/main.tf
@@ -47,22 +47,13 @@ resource "aws_iam_role_policy" "agentcore_execution" {
         Resource = "*"
       },
       {
-        # Container stdout/stderr is captured to the default runtime log group.
+        # Container stdout/stderr and OTLP logs + EMF metrics are sent to the
+        # default runtime log group.
         Sid    = "RuntimeLogs"
-        Effect = "Allow"
-        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents", "logs:DescribeLogStreams"]
-        Resource = [
-          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*"
-        ]
-      },
-      {
-        # EMF metrics exporter writes CloudWatch Embedded Metric Format logs here.
-        Sid    = "EmfMetricsLogs"
         Effect = "Allow"
         Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents", "logs:DescribeLogStreams", "logs:DescribeLogGroups"]
         Resource = [
-          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/agentcore/metrics/${local.runtime_name}",
-          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/agentcore/metrics/${local.runtime_name}:*"
+          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*"
         ]
       },
       {
@@ -91,6 +82,13 @@ resource "aws_iam_role_policy" "agentcore_execution" {
   })
 }
 
+# Log group for OTLP logs and EMF metrics. The OTLP CW Logs endpoint requires
+# the log group to exist before sending logs (unlike PutLogEvents which auto-creates).
+resource "aws_cloudwatch_log_group" "agent_logs" {
+  name              = "/aws/bedrock-agentcore/runtimes/${local.runtime_name}"
+  retention_in_days = 7
+}
+
 # Short-term memory for session-scoped conversation history.
 resource "aws_bedrockagentcore_memory" "stm" {
   name                 = "observability_stm_${random_string.suffix.result}"
@@ -113,19 +111,20 @@ resource "aws_bedrockagentcore_agent_runtime" "observability" {
     network_mode = "PUBLIC"
   }
 
-  # Only the trace endpoint is overridden: the runtime's injected OTLP endpoint targets
-  # a Python-only sidecar, so the ADOT Java agent ships spans collector-less (SigV4) to
-  # X-Ray instead. OTEL_RESOURCE_ATTRIBUTES is intentionally NOT set: AgentCore injects
-  # it with cloud.resource_id + cloud.platform, which is what links the spans to this
-  # runtime in the GenAI Observability "Bedrock AgentCore" tab. Overriding it breaks that.
+  # Observability configuration following the AgentCore docs pattern:
+  # - Traces: OTLP → X-Ray endpoint (SigV4, collector-less)
+  # - Logs: OTLP → CloudWatch Logs endpoint (SigV4, structured with trace correlation)
+  # - Metrics: EMF via PutLogEvents to the same log group (ADOT agent's awsemf exporter)
   #
-  # OTEL_EXPORTER_OTLP_LOGS_HEADERS configures the ADOT Java agent's built-in EMF
-  # exporter (activated by OTEL_METRICS_EXPORTER=awsemf in the Dockerfile). Any OTel
-  # metrics the app produces (custom Micrometer counters, gauges, timers) are converted
-  # to CloudWatch EMF logs and sent directly via PutLogEvents — no collector needed.
+  # OTEL_EXPORTER_OTLP_LOGS_HEADERS serves dual purpose: it configures both the OTLP
+  # logs exporter (target log group/stream) and the EMF metrics exporter (namespace).
+  # OTEL_RESOURCE_ATTRIBUTES is intentionally NOT set — AgentCore injects it with
+  # cloud.resource_id + cloud.platform, which links spans to this runtime in the
+  # GenAI Observability dashboard.
   environment_variables = {
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "https://xray.${var.aws_region}.amazonaws.com/v1/traces"
-    OTEL_EXPORTER_OTLP_LOGS_HEADERS    = "x-aws-log-group=/aws/agentcore/metrics/${local.runtime_name},x-aws-log-stream=emf,x-aws-metric-namespace=AgentCore/SpringAI"
+    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT   = "https://logs.${var.aws_region}.amazonaws.com/v1/logs"
+    OTEL_EXPORTER_OTLP_LOGS_HEADERS    = "x-aws-log-group=${aws_cloudwatch_log_group.agent_logs.name},x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore"
     AGENTCORE_MEMORY_ID                = aws_bedrockagentcore_memory.stm.id
   }
 }

--- a/examples/spring-ai-agentcore-observability/terraform/main.tf
+++ b/examples/spring-ai-agentcore-observability/terraform/main.tf
@@ -56,6 +56,16 @@ resource "aws_iam_role_policy" "agentcore_execution" {
         ]
       },
       {
+        # EMF metrics exporter writes CloudWatch Embedded Metric Format logs here.
+        Sid    = "EmfMetricsLogs"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents", "logs:DescribeLogStreams", "logs:DescribeLogGroups"]
+        Resource = [
+          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/agentcore/metrics/${local.runtime_name}",
+          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/agentcore/metrics/${local.runtime_name}:*"
+        ]
+      },
+      {
         # OTLP traces exporter posts spans to the X-Ray endpoint (Transaction Search).
         Sid      = "XRayWrite"
         Effect   = "Allow"
@@ -81,6 +91,12 @@ resource "aws_iam_role_policy" "agentcore_execution" {
   })
 }
 
+# Short-term memory for session-scoped conversation history.
+resource "aws_bedrockagentcore_memory" "stm" {
+  name                 = "observability_stm_${random_string.suffix.result}"
+  event_expiry_duration = 7
+}
+
 # IAM-authenticated AgentCore runtime. Observability is configured through the OTEL_*
 # environment variables consumed by the ADOT Java agent inside the container.
 resource "aws_bedrockagentcore_agent_runtime" "observability" {
@@ -102,8 +118,14 @@ resource "aws_bedrockagentcore_agent_runtime" "observability" {
   # X-Ray instead. OTEL_RESOURCE_ATTRIBUTES is intentionally NOT set: AgentCore injects
   # it with cloud.resource_id + cloud.platform, which is what links the spans to this
   # runtime in the GenAI Observability "Bedrock AgentCore" tab. Overriding it breaks that.
+  #
+  # OTEL_EXPORTER_OTLP_LOGS_HEADERS configures the ADOT Java agent's built-in EMF
+  # exporter (activated by OTEL_METRICS_EXPORTER=awsemf in the Dockerfile). Any OTel
+  # metrics the app produces (custom Micrometer counters, gauges, timers) are converted
+  # to CloudWatch EMF logs and sent directly via PutLogEvents — no collector needed.
   environment_variables = {
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "https://xray.${var.aws_region}.amazonaws.com/v1/traces"
-    AGENTCORE_MEMORY_ID                = var.memory_id
+    OTEL_EXPORTER_OTLP_LOGS_HEADERS    = "x-aws-log-group=/aws/agentcore/metrics/${local.runtime_name},x-aws-log-stream=emf,x-aws-metric-namespace=AgentCore/SpringAI"
+    AGENTCORE_MEMORY_ID                = aws_bedrockagentcore_memory.stm.id
   }
 }

--- a/examples/spring-ai-agentcore-observability/terraform/main.tf
+++ b/examples/spring-ai-agentcore-observability/terraform/main.tf
@@ -1,0 +1,109 @@
+data "aws_caller_identity" "current" {}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+locals {
+  runtime_name = "spring_ai_agentcore_observability_${random_string.suffix.result}"
+
+  # Image URI is written by build-and-push.sh; fall back to the variable otherwise.
+  container_uri = fileexists("image-uri.txt") ? trimspace(file("image-uri.txt")) : var.container_uri
+}
+
+# Execution role assumed by the AgentCore runtime.
+resource "aws_iam_role" "agentcore_runtime" {
+  name = "SpringAiObservabilityRuntimeRole-${random_string.suffix.result}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "bedrock-agentcore.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+        Condition = {
+          StringEquals = { "aws:SourceAccount" = data.aws_caller_identity.current.account_id }
+          ArnLike      = { "aws:SourceArn" = "arn:aws:bedrock-agentcore:${var.aws_region}:${data.aws_caller_identity.current.account_id}:*" }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "agentcore_execution" {
+  name = "AgentCoreExecutionPolicy"
+  role = aws_iam_role.agentcore_runtime.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "EcrPull"
+        Effect   = "Allow"
+        Action   = ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer", "ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        # Container stdout/stderr is captured to the default runtime log group.
+        Sid    = "RuntimeLogs"
+        Effect = "Allow"
+        Action = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents", "logs:DescribeLogStreams"]
+        Resource = [
+          "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*"
+        ]
+      },
+      {
+        # OTLP traces exporter posts spans to the X-Ray endpoint (Transaction Search).
+        Sid      = "XRayWrite"
+        Effect   = "Allow"
+        Action   = ["xray:PutTraceSegments", "xray:PutTelemetryRecords", "xray:GetSamplingRules", "xray:GetSamplingTargets"]
+        Resource = "*"
+      },
+      {
+        Sid    = "BedrockInvoke"
+        Effect = "Allow"
+        Action = ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"]
+        Resource = [
+          "arn:aws:bedrock:*::foundation-model/*",
+          "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/*"
+        ]
+      },
+      {
+        Sid      = "AgentCoreMemory"
+        Effect   = "Allow"
+        Action   = ["bedrock-agentcore:*"]
+        Resource = "arn:aws:bedrock-agentcore:${var.aws_region}:${data.aws_caller_identity.current.account_id}:memory/*"
+      }
+    ]
+  })
+}
+
+# IAM-authenticated AgentCore runtime. Observability is configured through the OTEL_*
+# environment variables consumed by the ADOT Java agent inside the container.
+resource "aws_bedrockagentcore_agent_runtime" "observability" {
+  agent_runtime_name = local.runtime_name
+  role_arn           = aws_iam_role.agentcore_runtime.arn
+
+  agent_runtime_artifact {
+    container_configuration {
+      container_uri = local.container_uri
+    }
+  }
+
+  network_configuration {
+    network_mode = "PUBLIC"
+  }
+
+  # Only the trace endpoint is overridden: the runtime's injected OTLP endpoint targets
+  # a Python-only sidecar, so the ADOT Java agent ships spans collector-less (SigV4) to
+  # X-Ray instead. OTEL_RESOURCE_ATTRIBUTES is intentionally NOT set: AgentCore injects
+  # it with cloud.resource_id + cloud.platform, which is what links the spans to this
+  # runtime in the GenAI Observability "Bedrock AgentCore" tab. Overriding it breaks that.
+  environment_variables = {
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "https://xray.${var.aws_region}.amazonaws.com/v1/traces"
+    AGENTCORE_MEMORY_ID                = var.memory_id
+  }
+}

--- a/examples/spring-ai-agentcore-observability/terraform/outputs.tf
+++ b/examples/spring-ai-agentcore-observability/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "runtime_arn" {
+  description = "ARN of the deployed AgentCore runtime"
+  value       = aws_bedrockagentcore_agent_runtime.observability.agent_runtime_arn
+}
+
+output "runtime_name" {
+  description = "AgentCore runtime name (also used as service.name in traces)"
+  value       = local.runtime_name
+}
+
+output "container_uri" {
+  description = "Container image URI used for deployment"
+  value       = local.container_uri
+}
+
+output "region" {
+  description = "Deployment region"
+  value       = var.aws_region
+}

--- a/examples/spring-ai-agentcore-observability/terraform/variables.tf
+++ b/examples/spring-ai-agentcore-observability/terraform/variables.tf
@@ -9,9 +9,3 @@ variable "container_uri" {
   type        = string
   default     = ""
 }
-
-variable "memory_id" {
-  description = "AgentCore Memory ID for short-term memory"
-  type        = string
-  default     = ""
-}

--- a/examples/spring-ai-agentcore-observability/terraform/variables.tf
+++ b/examples/spring-ai-agentcore-observability/terraform/variables.tf
@@ -1,0 +1,17 @@
+variable "aws_region" {
+  description = "AWS region for deployment"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "container_uri" {
+  description = "Container URI for the AgentCore runtime (fallback if image-uri.txt is not found)"
+  type        = string
+  default     = ""
+}
+
+variable "memory_id" {
+  description = "AgentCore Memory ID for short-term memory"
+  type        = string
+  default     = ""
+}

--- a/examples/spring-ai-agentcore-observability/terraform/versions.tf
+++ b/examples/spring-ai-agentcore-observability/terraform/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.18.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>spring-ai-agentcore-code-interpreter</module>
         <module>spring-ai-agentcore-browser</module>
         <module>spring-ai-agentcore-evaluations</module>
+        <module>spring-ai-agentcore-otel-extension</module>
         <module>build-tools/spring-ai-agentcore-rewrite-recipes</module>
     </modules>
 

--- a/spring-ai-agentcore-otel-extension/README.md
+++ b/spring-ai-agentcore-otel-extension/README.md
@@ -37,16 +37,14 @@ RUN curl -fsSL -o /app/aws-opentelemetry-agent.jar \
     "https://repo1.maven.org/maven2/org/springaicommunity/spring-ai-agentcore-otel-extension/${AGENTCORE_EXT_VERSION}/spring-ai-agentcore-otel-extension-${AGENTCORE_EXT_VERSION}.jar"
 
 ENV JAVA_TOOL_OPTIONS="-javaagent:/app/aws-opentelemetry-agent.jar" \
-    OTEL_JAVAAGENT_EXTENSIONS=/app/agentcore-otel-extension.jar \
-    OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
-    OTEL_TRACES_EXPORTER=otlp \
-    OTEL_LOGS_EXPORTER=otlp \
-    OTEL_METRICS_EXPORTER=none
+    OTEL_JAVAAGENT_EXTENSIONS=/app/agentcore-otel-extension.jar
 ```
 
-The trace endpoint is set via Terraform/environment variable:
+The trace and log endpoints are set via Terraform/environment variables:
 ```
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://xray.<region>.amazonaws.com/v1/traces
+OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://logs.<region>.amazonaws.com/v1/logs
+OTEL_EXPORTER_OTLP_LOGS_HEADERS=x-aws-log-group=<log-group>,x-aws-log-stream=runtime-logs,x-aws-metric-namespace=bedrock-agentcore
 ```
 
 ### Non-runtime hosted agents (ECS, EKS, EC2, Lambda)

--- a/spring-ai-agentcore-otel-extension/README.md
+++ b/spring-ai-agentcore-otel-extension/README.md
@@ -40,7 +40,7 @@ ENV JAVA_TOOL_OPTIONS="-javaagent:/app/aws-opentelemetry-agent.jar" \
     OTEL_JAVAAGENT_EXTENSIONS=/app/agentcore-otel-extension.jar \
     OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
     OTEL_TRACES_EXPORTER=otlp \
-    OTEL_LOGS_EXPORTER=none \
+    OTEL_LOGS_EXPORTER=otlp \
     OTEL_METRICS_EXPORTER=none
 ```
 

--- a/spring-ai-agentcore-otel-extension/README.md
+++ b/spring-ai-agentcore-otel-extension/README.md
@@ -1,0 +1,104 @@
+# Spring AI AgentCore OTel Extension
+
+A lightweight OTel Java agent extension that configures observability for Java agents
+targeting the **CloudWatch GenAI Observability** dashboard. It bridges the gap between
+Python (which gets automatic instrumentation from the ADOT Python distro) and Java.
+
+Activates when `AGENT_OBSERVABILITY_ENABLED=true` — no-op otherwise.
+
+## What it does
+
+| Feature | Purpose |
+|---------|---------|
+| `aws.service.type=gen_ai_agent` resource attribute | Required for the "Bedrock AgentCore" dashboard tab |
+| `session.id` baggage → span attribute | Groups traces by session in the dashboard |
+| `parentbased_always_on` sampler | 100% span capture for agent observability |
+| Disable AWS resource detectors | Prevents `cloud.platform=aws_ec2` from overriding AgentCore's value |
+| Disable Application Signals | Avoids duplicate cost with Transaction Search |
+| Disable `http-url-connection` instrumentation | Suppresses IMDS credential-fetching noise |
+| Disable Tomcat/Servlet instrumentation | Avoids duplicate server spans (Spring MVC provides one) |
+
+All settings are defaults — override any with environment variables.
+
+## Usage
+
+### AgentCore Runtime-hosted agents
+
+AgentCore injects `AGENT_OBSERVABILITY_ENABLED=true` and `OTEL_RESOURCE_ATTRIBUTES` automatically.
+You only need to add the extension to your Dockerfile:
+
+```dockerfile
+ARG ADOT_VERSION=v2.26.2
+ARG AGENTCORE_EXT_VERSION=1.1.0
+
+RUN curl -fsSL -o /app/aws-opentelemetry-agent.jar \
+    "https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/${ADOT_VERSION}/aws-opentelemetry-agent.jar" \
+ && curl -fsSL -o /app/agentcore-otel-extension.jar \
+    "https://repo1.maven.org/maven2/org/springaicommunity/spring-ai-agentcore-otel-extension/${AGENTCORE_EXT_VERSION}/spring-ai-agentcore-otel-extension-${AGENTCORE_EXT_VERSION}.jar"
+
+ENV JAVA_TOOL_OPTIONS="-javaagent:/app/aws-opentelemetry-agent.jar" \
+    OTEL_JAVAAGENT_EXTENSIONS=/app/agentcore-otel-extension.jar \
+    OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+    OTEL_TRACES_EXPORTER=otlp \
+    OTEL_LOGS_EXPORTER=none \
+    OTEL_METRICS_EXPORTER=none
+```
+
+The trace endpoint is set via Terraform/environment variable:
+```
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://xray.<region>.amazonaws.com/v1/traces
+```
+
+### Non-runtime hosted agents (ECS, EKS, EC2, Lambda)
+
+For agents running outside AgentCore Runtime, set the following environment variables
+in addition to the Dockerfile setup above:
+
+```bash
+# Activate the extension
+AGENT_OBSERVABILITY_ENABLED=true
+
+# Resource attributes (AgentCore would inject these on-runtime; set manually here)
+OTEL_RESOURCE_ATTRIBUTES=service.name=<your-agent-name>,cloud.resource_id=<AgentEndpointArn>:<EndpointName>
+
+# Trace export endpoint
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://xray.<region>.amazonaws.com/v1/traces
+
+# Protocol and exporters
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_TRACES_EXPORTER=otlp
+
+# Optional: OTLP logs export (if not using stdout)
+OTEL_LOGS_EXPORTER=otlp
+OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://logs.<region>.amazonaws.com/v1/logs
+OTEL_EXPORTER_OTLP_LOGS_HEADERS=x-aws-log-group=/aws/bedrock-agentcore/runtimes/<agent-id>,x-aws-log-stream=runtime-logs
+```
+
+The IAM role must have `xray:PutTraceSegments`, `xray:PutTelemetryRecords`,
+`xray:GetSamplingRules`, and `xray:GetSamplingTargets` permissions.
+
+## Prerequisites
+
+- [CloudWatch Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Enable-TransactionSearch.html)
+  enabled (one-time, per account/region)
+- ADOT Java agent v2.10+ (tested with v2.26.2)
+
+## How it works
+
+The extension implements `AutoConfigurationCustomizerProvider` — an OTel Java agent SPI
+that runs during agent initialization (before the application starts). It merges resource
+attributes and registers a `SpanProcessor` for session ID propagation. Because it runs in
+the agent's classloader, it can modify the resource before it's sealed.
+
+## Overriding defaults
+
+Every property set by the extension can be overridden with environment variables:
+
+```bash
+# Re-enable Tomcat instrumentation
+OTEL_INSTRUMENTATION_TOMCAT_ENABLED=true
+
+# Use a different sampler
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.1
+```

--- a/spring-ai-agentcore-otel-extension/pom.xml
+++ b/spring-ai-agentcore-otel-extension/pom.xml
@@ -37,6 +37,24 @@
             <version>${opentelemetry.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <version>${opentelemetry.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.27.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/spring-ai-agentcore-otel-extension/pom.xml
+++ b/spring-ai-agentcore-otel-extension/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springaicommunity</groupId>
+        <artifactId>spring-ai-agentcore-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-ai-agentcore-otel-extension</artifactId>
+    <name>Spring AI AgentCore OTel Extension</name>
+    <description>OTel Java agent extension that adds aws.service.type=gen_ai_agent resource attribute for the CloudWatch GenAI Observability dashboard</description>
+
+    <properties>
+        <opentelemetry.version>1.49.0</opentelemetry.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
+            <version>${opentelemetry.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>${opentelemetry.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>${opentelemetry.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
+++ b/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
@@ -79,10 +79,16 @@ public class AgentCoreResourceCustomizerProvider implements AutoConfigurationCus
 		Map<String, String> properties = new HashMap<>();
 		// 100% span capture for agent observability
 		properties.put("otel.traces.sampler", "parentbased_always_on");
-		// OTLP exporters for traces and logs (SigV4 endpoints configured via env vars)
+		// OTLP exporters for traces and logs (SigV4-signed to AWS endpoints)
 		properties.put("otel.traces.exporter", "otlp");
 		properties.put("otel.logs.exporter", "otlp");
 		properties.put("otel.exporter.otlp.protocol", "http/protobuf");
+		// Auto-derive OTLP endpoints from AWS_REGION (matches Python distro behavior)
+		String region = getAwsRegion();
+		if (region != null) {
+			properties.put("otel.exporter.otlp.traces.endpoint", "https://xray." + region + ".amazonaws.com/v1/traces");
+			properties.put("otel.exporter.otlp.logs.endpoint", "https://logs." + region + ".amazonaws.com/v1/logs");
+		}
 		// Disable AWS resource detectors so they don't override AgentCore's injected
 		// cloud.platform=aws_bedrock_agentcore with cloud.platform=aws_ec2
 		properties.put("otel.resource.providers.aws.enabled", "false");
@@ -103,6 +109,14 @@ public class AgentCoreResourceCustomizerProvider implements AutoConfigurationCus
 		properties.put("otel.instrumentation.tomcat.enabled", "false");
 		properties.put("otel.instrumentation.servlet.enabled", "false");
 		return properties;
+	}
+
+	private static String getAwsRegion() {
+		String region = System.getenv("AWS_REGION");
+		if (region == null) {
+			region = System.getenv("AWS_DEFAULT_REGION");
+		}
+		return region;
 	}
 
 	static boolean isAgentObservabilityEnabled() {

--- a/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
+++ b/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
@@ -67,6 +67,9 @@ public class AgentCoreResourceCustomizerProvider implements AutoConfigurationCus
 
 		autoConfiguration.addTracerProviderCustomizer(this::addSessionBaggageProcessor);
 
+		autoConfiguration
+			.addSpanExporterCustomizer((exporter, config) -> new AwsSdkGenAiSpanRenamingExporter(exporter));
+
 		autoConfiguration.addPropertiesSupplier(this::getDefaultProperties);
 	}
 

--- a/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
+++ b/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
@@ -84,6 +84,10 @@ public class AgentCoreResourceCustomizerProvider implements AutoConfigurationCus
 		properties.put("otel.resource.providers.aws.enabled", "false");
 		// Disable Application Signals to avoid duplicate cost with Transaction Search
 		properties.put("otel.aws.application.signals.enabled", "false");
+		// Enable the built-in EMF exporter so custom Micrometer metrics are sent to
+		// CloudWatch via PutLogEvents. The target log group/stream/namespace must be
+		// configured via OTEL_EXPORTER_OTLP_LOGS_HEADERS at deployment time.
+		properties.put("otel.metrics.exporter", "awsemf");
 		// Disable http-url-connection instrumentation to suppress IMDS credential
 		// fetching noise (169.254.169.254) — equivalent to Python disabling
 		// urllib3/requests/http
@@ -91,6 +95,7 @@ public class AgentCoreResourceCustomizerProvider implements AutoConfigurationCus
 		// Disable Tomcat/Servlet server spans — Spring MVC observation provides the
 		// server span at a higher level. Equivalent to Python disabling low-level http
 		// server instrumentation to avoid duplicates with framework spans.
+		// HTTP metrics (http.server.request.duration) are provided by Spring MVC.
 		properties.put("otel.instrumentation.tomcat.enabled", "false");
 		properties.put("otel.instrumentation.servlet.enabled", "false");
 		return properties;

--- a/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
+++ b/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
@@ -79,6 +79,10 @@ public class AgentCoreResourceCustomizerProvider implements AutoConfigurationCus
 		Map<String, String> properties = new HashMap<>();
 		// 100% span capture for agent observability
 		properties.put("otel.traces.sampler", "parentbased_always_on");
+		// OTLP exporters for traces and logs (SigV4 endpoints configured via env vars)
+		properties.put("otel.traces.exporter", "otlp");
+		properties.put("otel.logs.exporter", "otlp");
+		properties.put("otel.exporter.otlp.protocol", "http/protobuf");
 		// Disable AWS resource detectors so they don't override AgentCore's injected
 		// cloud.platform=aws_bedrock_agentcore with cloud.platform=aws_ec2
 		properties.put("otel.resource.providers.aws.enabled", "false");

--- a/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
+++ b/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.otel;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+
+/**
+ * OTel Java agent extension for Amazon Bedrock AgentCore Runtime. Activated when
+ * {@code AGENT_OBSERVABILITY_ENABLED=true} (injected by AgentCore into every container).
+ *
+ * <p>
+ * Mirrors what the Python ADOT auto-configurator does:
+ * <ul>
+ * <li>Adds {@code aws.service.type=gen_ai_agent} resource attribute (required for the
+ * GenAI Observability "Bedrock AgentCore" dashboard tab)</li>
+ * <li>Propagates {@code session.id} from baggage to span attributes (groups traces by
+ * session in the dashboard)</li>
+ * <li>Sets {@code parentbased_always_on} sampler (100% span capture for agent
+ * observability)</li>
+ * <li>Disables AWS cloud resource detectors (prevents {@code cloud.platform=aws_ec2} from
+ * overriding AgentCore's injected {@code cloud.platform=aws_bedrock_agentcore})</li>
+ * </ul>
+ *
+ * <p>
+ * Usage: set
+ * {@code OTEL_JAVAAGENT_EXTENSIONS=/path/to/spring-ai-agentcore-otel-extension.jar}
+ *
+ * @author Maximilian Schellhorn
+ */
+public class AgentCoreResourceCustomizerProvider implements AutoConfigurationCustomizerProvider {
+
+	private static final AttributeKey<String> AWS_SERVICE_TYPE = AttributeKey.stringKey("aws.service.type");
+
+	private static final String AGENT_OBSERVABILITY_ENABLED = "AGENT_OBSERVABILITY_ENABLED";
+
+	@Override
+	public void customize(AutoConfigurationCustomizer autoConfiguration) {
+		if (!isAgentObservabilityEnabled()) {
+			return;
+		}
+
+		autoConfiguration.addResourceCustomizer(
+				(resource, config) -> resource.merge(Resource.create(Attributes.of(AWS_SERVICE_TYPE, "gen_ai_agent"))));
+
+		autoConfiguration.addTracerProviderCustomizer(this::addSessionBaggageProcessor);
+
+		autoConfiguration.addPropertiesSupplier(this::getDefaultProperties);
+	}
+
+	private SdkTracerProviderBuilder addSessionBaggageProcessor(SdkTracerProviderBuilder builder,
+			ConfigProperties config) {
+		return builder.addSpanProcessor(new SessionBaggageSpanProcessor());
+	}
+
+	private Map<String, String> getDefaultProperties() {
+		Map<String, String> properties = new HashMap<>();
+		// 100% span capture for agent observability
+		properties.put("otel.traces.sampler", "parentbased_always_on");
+		// Disable AWS resource detectors so they don't override AgentCore's injected
+		// cloud.platform=aws_bedrock_agentcore with cloud.platform=aws_ec2
+		properties.put("otel.resource.providers.aws.enabled", "false");
+		// Disable Application Signals to avoid duplicate cost with Transaction Search
+		properties.put("otel.aws.application.signals.enabled", "false");
+		// Disable http-url-connection instrumentation to suppress IMDS credential
+		// fetching noise (169.254.169.254) — equivalent to Python disabling
+		// urllib3/requests/http
+		properties.put("otel.instrumentation.http-url-connection.enabled", "false");
+		// Disable Tomcat/Servlet server spans — Spring MVC observation provides the
+		// server span at a higher level. Equivalent to Python disabling low-level http
+		// server instrumentation to avoid duplicates with framework spans.
+		properties.put("otel.instrumentation.tomcat.enabled", "false");
+		properties.put("otel.instrumentation.servlet.enabled", "false");
+		return properties;
+	}
+
+	private static boolean isAgentObservabilityEnabled() {
+		String value = System.getenv(AGENT_OBSERVABILITY_ENABLED);
+		return "true".equalsIgnoreCase(value);
+	}
+
+}

--- a/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
+++ b/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProvider.java
@@ -75,7 +75,7 @@ public class AgentCoreResourceCustomizerProvider implements AutoConfigurationCus
 		return builder.addSpanProcessor(new SessionBaggageSpanProcessor());
 	}
 
-	private Map<String, String> getDefaultProperties() {
+	Map<String, String> getDefaultProperties() {
 		Map<String, String> properties = new HashMap<>();
 		// 100% span capture for agent observability
 		properties.put("otel.traces.sampler", "parentbased_always_on");
@@ -101,7 +101,7 @@ public class AgentCoreResourceCustomizerProvider implements AutoConfigurationCus
 		return properties;
 	}
 
-	private static boolean isAgentObservabilityEnabled() {
+	static boolean isAgentObservabilityEnabled() {
 		String value = System.getenv(AGENT_OBSERVABILITY_ENABLED);
 		return "true".equalsIgnoreCase(value);
 	}

--- a/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AwsSdkGenAiSpanRenamingExporter.java
+++ b/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/AwsSdkGenAiSpanRenamingExporter.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.otel;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.trace.data.DelegatingSpanData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+/**
+ * Span exporter wrapper that appends an {@code  (aws-sdk-2.2)} suffix to GenAI spans
+ * emitted by the OpenTelemetry AWS SDK v2 instrumentation.
+ *
+ * <p>
+ * Both the Spring AI {@code ChatModel} observation (bridged from Micrometer to OTel) and
+ * the OTel {@code aws-sdk-2.2} Bedrock Runtime instrumentation follow the GenAI semantic
+ * convention for span names — {@code <gen_ai.operation.name> <gen_ai.request.model>} —
+ * which makes them appear identical (e.g. both named
+ * {@code chat global.amazon.nova-2-lite-v1:0}) even though they sit at different layers
+ * of the call stack and carry complementary attributes. This wrapper disambiguates the
+ * AWS SDK side, leaving the Spring AI span untouched.
+ *
+ * <p>
+ * Detection uses two signals taken at export time, when all attributes are guaranteed to
+ * be present on the {@link SpanData}:
+ * <ul>
+ * <li><b>Instrumentation scope</b> — the span's {@link InstrumentationScopeInfo#getName()
+ * scope name} starts with {@code io.opentelemetry.aws-sdk-}, identifying spans produced
+ * by the OTel AWS SDK instrumentation (and not, for example, Spring AI's
+ * Micrometer-bridged span).</li>
+ * <li><b>GenAI semantic convention marker</b> — the span carries the
+ * {@code gen_ai.system} attribute, which the OTel GenAI conventions require on every
+ * GenAI client span and on no other kind of span. Using this attribute (instead of an
+ * enumerated list of operation names) means the wrapper continues to behave correctly as
+ * new GenAI operations are added to the spec or to AWS Bedrock.</li>
+ * </ul>
+ * Plain AWS SDK spans (e.g. {@code BedrockAgentCore.ListEvents}, {@code S3.GetObject})
+ * carry the AWS SDK scope but no {@code gen_ai.system} attribute, and are therefore left
+ * alone.
+ *
+ * <p>
+ * Why an exporter wrapper rather than a {@code SpanProcessor.onStart}: the OTel AWS SDK
+ * Bedrock instrumentation adds the {@code gen_ai.*} attributes after the request body is
+ * marshalled, which is after {@code SpanBuilder.startSpan()} has returned. A processor
+ * running at {@code onStart} would therefore see the span before those attributes are
+ * set. Running at export time avoids the race: the {@link SpanData} passed to
+ * {@link #export} carries every attribute the span will ever have.
+ *
+ * @author Andrei Shakirin
+ */
+class AwsSdkGenAiSpanRenamingExporter implements SpanExporter {
+
+	private static final String AWS_SDK_SCOPE_PREFIX = "io.opentelemetry.aws-sdk-";
+
+	private static final String SUFFIX = " (aws-sdk-2.2)";
+
+	private static final AttributeKey<String> GEN_AI_SYSTEM = AttributeKey.stringKey("gen_ai.system");
+
+	private final SpanExporter delegate;
+
+	AwsSdkGenAiSpanRenamingExporter(SpanExporter delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public CompletableResultCode export(Collection<SpanData> spans) {
+		List<SpanData> rewritten = new ArrayList<>(spans.size());
+		for (SpanData span : spans) {
+			rewritten.add(maybeRename(span));
+		}
+		return this.delegate.export(rewritten);
+	}
+
+	@Override
+	public CompletableResultCode flush() {
+		return this.delegate.flush();
+	}
+
+	@Override
+	public CompletableResultCode shutdown() {
+		return this.delegate.shutdown();
+	}
+
+	private static SpanData maybeRename(SpanData span) {
+		if (!isAwsSdkScope(span.getInstrumentationScopeInfo())) {
+			return span;
+		}
+		if (span.getAttributes().get(GEN_AI_SYSTEM) == null) {
+			return span;
+		}
+		String name = span.getName();
+		if (name == null || name.isEmpty() || name.endsWith(SUFFIX)) {
+			return span;
+		}
+		return new RenamedSpanData(span, name + SUFFIX);
+	}
+
+	private static boolean isAwsSdkScope(InstrumentationScopeInfo scope) {
+		if (scope == null) {
+			return false;
+		}
+		String name = scope.getName();
+		return name != null && name.startsWith(AWS_SDK_SCOPE_PREFIX);
+	}
+
+	private static final class RenamedSpanData extends DelegatingSpanData {
+
+		private final String name;
+
+		private RenamedSpanData(SpanData delegate, String name) {
+			super(delegate);
+			this.name = name;
+		}
+
+		@Override
+		public String getName() {
+			return this.name;
+		}
+
+	}
+
+}

--- a/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/SessionBaggageSpanProcessor.java
+++ b/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/SessionBaggageSpanProcessor.java
@@ -32,6 +32,9 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
  */
 class SessionBaggageSpanProcessor implements SpanProcessor {
 
+	// Baggage key set by AgentCore Runtime when invoking the container.
+	// Contract:
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore-observability.html
 	private static final String SESSION_ID_KEY = "session.id";
 
 	private static final AttributeKey<String> SESSION_ID_ATTR = AttributeKey.stringKey(SESSION_ID_KEY);

--- a/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/SessionBaggageSpanProcessor.java
+++ b/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/SessionBaggageSpanProcessor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.otel;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+
+/**
+ * Propagates {@code session.id} from OTel baggage to span attributes. AgentCore sets the
+ * session ID in baggage when invoking the runtime; this processor ensures it appears on
+ * every span so the GenAI Observability dashboard can group traces by session.
+ *
+ * @author Maximilian Schellhorn
+ */
+class SessionBaggageSpanProcessor implements SpanProcessor {
+
+	private static final String SESSION_ID_KEY = "session.id";
+
+	private static final AttributeKey<String> SESSION_ID_ATTR = AttributeKey.stringKey(SESSION_ID_KEY);
+
+	@Override
+	public void onStart(Context parentContext, ReadWriteSpan span) {
+		String sessionId = Baggage.fromContext(parentContext).getEntryValue(SESSION_ID_KEY);
+		if (sessionId != null && !sessionId.isEmpty()) {
+			span.setAttribute(SESSION_ID_ATTR, sessionId);
+		}
+	}
+
+	@Override
+	public boolean isStartRequired() {
+		return true;
+	}
+
+	@Override
+	public void onEnd(ReadableSpan span) {
+	}
+
+	@Override
+	public boolean isEndRequired() {
+		return false;
+	}
+
+}

--- a/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/package-info.java
+++ b/spring-ai-agentcore-otel-extension/src/main/java/org/springaicommunity/agentcore/otel/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OTel Java agent extension that adds AgentCore-specific resource attributes.
+ */
+package org.springaicommunity.agentcore.otel;

--- a/spring-ai-agentcore-otel-extension/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
+++ b/spring-ai-agentcore-otel-extension/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
@@ -1,0 +1,1 @@
+org.springaicommunity.agentcore.otel.AgentCoreResourceCustomizerProvider

--- a/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProviderTests.java
+++ b/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProviderTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.otel;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AgentCoreResourceCustomizerProviderTests {
+
+	@Test
+	void disabledWhenEnvironmentVariableIsNotSet() {
+		// AGENT_OBSERVABILITY_ENABLED is not set in the test environment
+		assertThat(AgentCoreResourceCustomizerProvider.isAgentObservabilityEnabled()).isFalse();
+	}
+
+	@Test
+	void defaultPropertiesSetAlwaysOnSampler() {
+		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
+
+		assertThat(props).containsEntry("otel.traces.sampler", "parentbased_always_on");
+	}
+
+	@Test
+	void defaultPropertiesDisableAwsResourceDetectors() {
+		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
+
+		assertThat(props).containsEntry("otel.resource.providers.aws.enabled", "false");
+	}
+
+	@Test
+	void defaultPropertiesDisableApplicationSignals() {
+		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
+
+		assertThat(props).containsEntry("otel.aws.application.signals.enabled", "false");
+	}
+
+	@Test
+	void defaultPropertiesEnableEmfExporter() {
+		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
+
+		assertThat(props).containsEntry("otel.metrics.exporter", "awsemf");
+	}
+
+	@Test
+	void defaultPropertiesDisableNoisyInstrumentations() {
+		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
+
+		assertThat(props).containsEntry("otel.instrumentation.http-url-connection.enabled", "false")
+			.containsEntry("otel.instrumentation.tomcat.enabled", "false")
+			.containsEntry("otel.instrumentation.servlet.enabled", "false");
+	}
+
+}

--- a/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProviderTests.java
+++ b/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProviderTests.java
@@ -47,6 +47,15 @@ class AgentCoreResourceCustomizerProviderTests {
 	}
 
 	@Test
+	void defaultPropertiesOmitEndpointsWhenRegionNotSet() {
+		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
+
+		// When AWS_REGION is not set, endpoints are not included (user must set them)
+		assertThat(props).doesNotContainKey("otel.exporter.otlp.traces.endpoint")
+			.doesNotContainKey("otel.exporter.otlp.logs.endpoint");
+	}
+
+	@Test
 	void defaultPropertiesDisableAwsResourceDetectors() {
 		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
 

--- a/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProviderTests.java
+++ b/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProviderTests.java
@@ -18,6 +18,13 @@ package org.springaicommunity.agentcore.otel;
 
 import java.util.Map;
 
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,63 +33,55 @@ class AgentCoreResourceCustomizerProviderTests {
 
 	@Test
 	void disabledWhenEnvironmentVariableIsNotSet() {
-		// AGENT_OBSERVABILITY_ENABLED is not set in the test environment
 		assertThat(AgentCoreResourceCustomizerProvider.isAgentObservabilityEnabled()).isFalse();
 	}
 
 	@Test
-	void defaultPropertiesSetAlwaysOnSampler() {
+	void defaultPropertiesConfigureObservabilityDefaults() {
 		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
 
-		assertThat(props).containsEntry("otel.traces.sampler", "parentbased_always_on");
-	}
-
-	@Test
-	void defaultPropertiesConfigureOtlpExporters() {
-		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
-
-		assertThat(props).containsEntry("otel.traces.exporter", "otlp")
+		assertThat(props).containsEntry("otel.traces.sampler", "parentbased_always_on")
+			.containsEntry("otel.traces.exporter", "otlp")
 			.containsEntry("otel.logs.exporter", "otlp")
-			.containsEntry("otel.exporter.otlp.protocol", "http/protobuf");
+			.containsEntry("otel.exporter.otlp.protocol", "http/protobuf")
+			.containsEntry("otel.metrics.exporter", "awsemf")
+			.containsEntry("otel.resource.providers.aws.enabled", "false")
+			.containsEntry("otel.aws.application.signals.enabled", "false")
+			.containsEntry("otel.instrumentation.http-url-connection.enabled", "false")
+			.containsEntry("otel.instrumentation.tomcat.enabled", "false")
+			.containsEntry("otel.instrumentation.servlet.enabled", "false");
 	}
 
 	@Test
 	void defaultPropertiesOmitEndpointsWhenRegionNotSet() {
 		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
 
-		// When AWS_REGION is not set, endpoints are not included (user must set them)
 		assertThat(props).doesNotContainKey("otel.exporter.otlp.traces.endpoint")
 			.doesNotContainKey("otel.exporter.otlp.logs.endpoint");
 	}
 
 	@Test
-	void defaultPropertiesDisableAwsResourceDetectors() {
-		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
+	void resourceContainsGenAiAgentServiceType() {
+		Resource base = Resource.getDefault();
+		Resource merged = base
+			.merge(Resource.create(Attributes.of(AttributeKey.stringKey("aws.service.type"), "gen_ai_agent")));
 
-		assertThat(props).containsEntry("otel.resource.providers.aws.enabled", "false");
-	}
+		InMemorySpanExporter exporter = InMemorySpanExporter.create();
+		SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+			.setResource(merged)
+			.addSpanProcessor(SimpleSpanProcessor.create(exporter))
+			.build();
 
-	@Test
-	void defaultPropertiesDisableApplicationSignals() {
-		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
+		Tracer tracer = tracerProvider.get("test");
+		tracer.spanBuilder("test").startSpan().end();
 
-		assertThat(props).containsEntry("otel.aws.application.signals.enabled", "false");
-	}
+		assertThat(exporter.getFinishedSpanItems()).hasSize(1);
+		assertThat(exporter.getFinishedSpanItems()
+			.get(0)
+			.getResource()
+			.getAttribute(AttributeKey.stringKey("aws.service.type"))).isEqualTo("gen_ai_agent");
 
-	@Test
-	void defaultPropertiesEnableEmfExporter() {
-		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
-
-		assertThat(props).containsEntry("otel.metrics.exporter", "awsemf");
-	}
-
-	@Test
-	void defaultPropertiesDisableNoisyInstrumentations() {
-		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
-
-		assertThat(props).containsEntry("otel.instrumentation.http-url-connection.enabled", "false")
-			.containsEntry("otel.instrumentation.tomcat.enabled", "false")
-			.containsEntry("otel.instrumentation.servlet.enabled", "false");
+		tracerProvider.close();
 	}
 
 }

--- a/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProviderTests.java
+++ b/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AgentCoreResourceCustomizerProviderTests.java
@@ -38,6 +38,15 @@ class AgentCoreResourceCustomizerProviderTests {
 	}
 
 	@Test
+	void defaultPropertiesConfigureOtlpExporters() {
+		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
+
+		assertThat(props).containsEntry("otel.traces.exporter", "otlp")
+			.containsEntry("otel.logs.exporter", "otlp")
+			.containsEntry("otel.exporter.otlp.protocol", "http/protobuf");
+	}
+
+	@Test
 	void defaultPropertiesDisableAwsResourceDetectors() {
 		Map<String, String> props = new AgentCoreResourceCustomizerProvider().getDefaultProperties();
 

--- a/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AwsSdkGenAiSpanRenamingExporterTests.java
+++ b/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AwsSdkGenAiSpanRenamingExporterTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.otel;
+
+import java.util.List;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the renamer's decision logic: append the suffix only when the span comes from
+ * the OTel AWS SDK instrumentation and follows the GenAI semantic convention.
+ */
+class AwsSdkGenAiSpanRenamingExporterTests {
+
+	@Test
+	void appendsSuffixToAwsSdkGenAiSpan() {
+		assertThat(exportName("io.opentelemetry.aws-sdk-2.2", "chat foo", true)).isEqualTo("chat foo (aws-sdk-2.2)");
+	}
+
+	@Test
+	void leavesAwsSdkNonGenAiSpanUnchanged() {
+		assertThat(exportName("io.opentelemetry.aws-sdk-2.2", "BedrockAgentCore.ListEvents", false))
+			.isEqualTo("BedrockAgentCore.ListEvents");
+	}
+
+	@Test
+	void leavesNonAwsSdkSpanUnchanged() {
+		// Spring AI's ChatModel observation produces an identically-named span at a
+		// different scope; it must not get the AWS SDK suffix.
+		assertThat(exportName("org.springframework.boot", "chat foo", true)).isEqualTo("chat foo");
+	}
+
+	private static String exportName(String scopeName, String spanName, boolean genAi) {
+		InMemorySpanExporter delegate = InMemorySpanExporter.create();
+		Attributes attrs = genAi ? Attributes.of(AttributeKey.stringKey("gen_ai.system"), "aws.bedrock")
+				: Attributes.empty();
+		SpanData span = TestSpanData.builder()
+			.setName(spanName)
+			.setKind(SpanKind.CLIENT)
+			.setStatus(StatusData.unset())
+			.setStartEpochNanos(0L)
+			.setEndEpochNanos(1L)
+			.setHasEnded(true)
+			.setInstrumentationScopeInfo(InstrumentationScopeInfo.create(scopeName))
+			.setAttributes(attrs)
+			.build();
+
+		new AwsSdkGenAiSpanRenamingExporter(delegate).export(List.of(span));
+
+		return delegate.getFinishedSpanItems().getFirst().getName();
+	}
+
+}

--- a/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/SessionBaggageSpanProcessorTests.java
+++ b/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/SessionBaggageSpanProcessorTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.otel;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SessionBaggageSpanProcessorTests {
+
+	private static final AttributeKey<String> SESSION_ID_ATTR = AttributeKey.stringKey("session.id");
+
+	private InMemorySpanExporter exporter;
+
+	private SdkTracerProvider tracerProvider;
+
+	private Tracer tracer;
+
+	@BeforeEach
+	void setUp() {
+		this.exporter = InMemorySpanExporter.create();
+		this.tracerProvider = SdkTracerProvider.builder()
+			.addSpanProcessor(new SessionBaggageSpanProcessor())
+			.addSpanProcessor(SimpleSpanProcessor.create(this.exporter))
+			.build();
+		this.tracer = this.tracerProvider.get("test");
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.tracerProvider.close();
+	}
+
+	@Test
+	void sessionIdFromBaggagePropagatedToSpanAttribute() {
+		Context context = Context.current().with(Baggage.builder().put("session.id", "sess-abc-123").build());
+
+		try (Scope ignored = context.makeCurrent()) {
+			Span span = this.tracer.spanBuilder("test-span").startSpan();
+			span.end();
+		}
+
+		assertThat(this.exporter.getFinishedSpanItems()).hasSize(1);
+		assertThat(this.exporter.getFinishedSpanItems().get(0).getAttributes().get(SESSION_ID_ATTR))
+			.isEqualTo("sess-abc-123");
+	}
+
+	@Test
+	void noAttributeWhenBaggageIsMissing() {
+		Span span = this.tracer.spanBuilder("test-span").startSpan();
+		span.end();
+
+		assertThat(this.exporter.getFinishedSpanItems()).hasSize(1);
+		assertThat(this.exporter.getFinishedSpanItems().get(0).getAttributes().get(SESSION_ID_ATTR)).isNull();
+	}
+
+	@Test
+	void noAttributeWhenBaggageIsEmpty() {
+		Context context = Context.current().with(Baggage.builder().put("session.id", "").build());
+
+		try (Scope ignored = context.makeCurrent()) {
+			Span span = this.tracer.spanBuilder("test-span").startSpan();
+			span.end();
+		}
+
+		assertThat(this.exporter.getFinishedSpanItems()).hasSize(1);
+		assertThat(this.exporter.getFinishedSpanItems().get(0).getAttributes().get(SESSION_ID_ATTR)).isNull();
+	}
+
+}

--- a/spring-ai-agentcore-runtime-starter/pom.xml
+++ b/spring-ai-agentcore-runtime-starter/pom.xml
@@ -85,6 +85,16 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreObservabilityAutoConfiguration.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/autoconfigure/AgentCoreObservabilityAutoConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.autoconfigure;
+
+import io.micrometer.observation.ObservationPredicate;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.observation.ServerRequestObservationContext;
+
+/**
+ * Auto-configuration for AgentCore observability. Bridges Micrometer tracing to the ADOT
+ * Java agent's OpenTelemetry instance and filters health-check noise from traces.
+ *
+ * <p>
+ * Activates only when both OpenTelemetry API and Micrometer Observation are on the
+ * classpath.
+ *
+ * @author Maximilian Schellhorn
+ */
+@Configuration
+@ConditionalOnClass({ OpenTelemetry.class, ObservationPredicate.class })
+public class AgentCoreObservabilityAutoConfiguration {
+
+	/**
+	 * Routes the Micrometer tracing bridge through the OpenTelemetry instance installed
+	 * by the ADOT Java agent. Without the agent this resolves to a no-op instance.
+	 * @return the agent-installed {@link OpenTelemetry} instance
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	OpenTelemetry openTelemetry() {
+		return GlobalOpenTelemetry.get();
+	}
+
+	/**
+	 * Suppresses tracing of AgentCore health checks ({@code /ping}) and actuator
+	 * endpoints, which the runtime polls continuously.
+	 * @return an {@link ObservationPredicate} that filters health-check observations
+	 */
+	@Bean
+	ObservationPredicate agentCoreHealthCheckFilter() {
+		return (name, context) -> {
+			if (context instanceof ServerRequestObservationContext serverContext) {
+				String uri = serverContext.getCarrier().getRequestURI();
+				return !uri.equals("/ping") && !uri.startsWith("/actuator");
+			}
+			return true;
+		};
+	}
+
+}

--- a/spring-ai-agentcore-runtime-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-ai-agentcore-runtime-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 org.springaicommunity.agentcore.autoconfigure.AgentCoreAutoConfiguration
+org.springaicommunity.agentcore.autoconfigure.AgentCoreObservabilityAutoConfiguration


### PR DESCRIPTION
Adds end-to-end OpenTelemetry observability for Java agents on AgentCore Runtime (Parity to the Python ADOT auto-instrumentation path)

<img width="1169" height="703" alt="Screenshot 2026-06-02 at 09 12 04" src="https://github.com/user-attachments/assets/27ba2a71-1ca6-4114-a693-2ac5fdac04be" />

<img width="1098" height="640" alt="Screenshot 2026-06-02 at 09 09 46" src="https://github.com/user-attachments/assets/559df1ed-f865-47de-b54c-66bc52d168dc" />

<img width="1660" height="521" alt="Screenshot 2026-06-02 at 09 10 48" src="https://github.com/user-attachments/assets/f51c8cb8-b9a0-481c-b11a-778742f729d9" />

<img width="1688" height="465" alt="Screenshot 2026-06-02 at 09 11 21" src="https://github.com/user-attachments/assets/61a5b983-3055-4ad3-aa3c-1546acf6a4fd" />

### High-Level summary

**`spring-ai-agentcore-otel-extension`** — A (5KB) OTel Java agent extension that configures observability for the CloudWatch GenAI Observability dashboard. Activated by `AGENT_OBSERVABILITY_ENABLED=true` (injected by AgentCore). It:
- Adds `aws.service.type=gen_ai_agent` resource attribute (required for the Bedrock AgentCore dashboard tab)
- Propagates `session.id` from baggage to span attributes (enables session grouping)
- Sets 100% sampling, disables AWS resource detectors and Application Signals
- Suppresses IMDS and Tomcat/Servlet noise spans

**`AgentCoreObservabilityAutoConfiguration`** (in runtime-starter) — Auto-configures the Micrometer→OTel bridge and filters `/ping` health-check noise from traces. Zero setup for users.

**`examples/spring-ai-agentcore-observability`** — A deployable Spring AI + Bedrock agent with:
- Short-term memory (AgentCore Memory)
- Tool calling (date/time tool)
- Full trace visibility: ChatClient → advisor → model (with token usage) → tool → AWS SDK spans
- Terraform for one-command deploy to AgentCore Runtime

### Further reading

[Example Overview](https://github.com/spring-ai-community/spring-ai-agentcore/blob/70c5f2cc9b7bc4d2c38f871887c6d06994015da2/examples/spring-ai-agentcore-observability/README.md)

[Extension](https://github.com/spring-ai-community/spring-ai-agentcore/blob/70c5f2cc9b7bc4d2c38f871887c6d06994015da2/spring-ai-agentcore-otel-extension/README.md)

### Decisions

- **Don't override `OTEL_RESOURCE_ATTRIBUTES`** — AgentCore injects `cloud.resource_id` and `cloud.platform` at container start. Overriding it breaks dashboard linkage.
- **Traces only, no metrics export** — The ADOT Java agent lacks SigV4 support for the CloudWatch monitoring endpoint. Token usage is captured on spans. Service-level metrics are provided by AgentCore automatically.

### Testing

Deployed and verified on AgentCore Runtime (us-east-1). Spans confirmed in `aws/spans` with all required attributes (`aws.service.type`, `cloud.resource_id`, `cloud.platform`, `session.id`). Agent visible in GenAI Observability → Bedrock AgentCore tab.