### PR TITLE
feat(runtime): add session.id OTel baggage propagation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.48.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/spring-ai-agentcore-runtime-starter/pom.xml
+++ b/spring-ai-agentcore-runtime-starter/pom.xml
@@ -85,6 +85,16 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
@@ -95,6 +105,11 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/observability/AgentCoreBaggagePropagationAutoConfiguration.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/observability/AgentCoreBaggagePropagationAutoConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.observability;
+
+import io.opentelemetry.api.baggage.Baggage;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+
+/**
+ * Auto-configuration that registers the {@link AgentCoreSessionBaggageFilter} when
+ * OpenTelemetry is on the classpath.
+ *
+ * <p>
+ * The filter reads {@code X-Amzn-Bedrock-AgentCore-Runtime-Session-Id} from inbound
+ * requests and injects it into OTel Baggage as {@code session.id}, enabling downstream
+ * propagation via W3C baggage header and span enrichment via
+ * {@code SessionBaggageSpanProcessor}.
+ *
+ * <p>
+ * Disable with {@code spring.ai.agentcore.baggage.enabled=false}.
+ *
+ * @author Vaquar Khan
+ */
+@AutoConfiguration
+@ConditionalOnClass(Baggage.class)
+@ConditionalOnProperty(name = "spring.ai.agentcore.baggage.enabled", havingValue = "true", matchIfMissing = true)
+public class AgentCoreBaggagePropagationAutoConfiguration {
+
+	private static final int FILTER_ORDER = Ordered.HIGHEST_PRECEDENCE + 10;
+
+	/**
+	 * Registers the session baggage filter for the {@code /invocations} endpoint.
+	 * @return the filter registration bean
+	 */
+	@Bean
+	public FilterRegistrationBean<AgentCoreSessionBaggageFilter> agentCoreSessionBaggageFilter() {
+		FilterRegistrationBean<AgentCoreSessionBaggageFilter> registration = new FilterRegistrationBean<>();
+		registration.setFilter(new AgentCoreSessionBaggageFilter());
+		registration.addUrlPatterns("/invocations");
+		registration.setOrder(FILTER_ORDER);
+		return registration;
+	}
+
+}

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/observability/AgentCoreSessionBaggageFilter.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/observability/AgentCoreSessionBaggageFilter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.observability;
+
+import java.io.IOException;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.context.Scope;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springaicommunity.agentcore.context.AgentCoreHeaders;
+
+/**
+ * Servlet filter that reads the AgentCore session header and injects it into OTel Baggage
+ * as {@code session.id}.
+ *
+ * <p>
+ * This completes the observability circuit: the filter writes {@code session.id} into
+ * baggage, and downstream span processors (e.g. {@code SessionBaggageSpanProcessor} from
+ * the OTel extension) read it back to enrich span attributes.
+ *
+ * <p>
+ * Downstream HTTP calls made within the filter scope will automatically propagate the
+ * baggage via the W3C {@code baggage} header when {@code W3CBaggagePropagator} is
+ * configured.
+ *
+ * @author Vaquar Khan
+ * @see AgentCoreHeaders#SESSION_ID
+ */
+public final class AgentCoreSessionBaggageFilter implements Filter {
+
+	/** OTel Baggage key for the AgentCore session identifier. */
+	static final String BAGGAGE_KEY = "session.id";
+
+	@Override
+	public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
+			throws IOException, ServletException {
+		if (request instanceof HttpServletRequest httpRequest) {
+			String sessionId = httpRequest.getHeader(AgentCoreHeaders.SESSION_ID);
+			if (sessionId != null && !sessionId.isBlank()) {
+				Baggage baggage = Baggage.current().toBuilder().put(BAGGAGE_KEY, sessionId).build();
+				try (Scope ignored = baggage.makeCurrent()) {
+					chain.doFilter(request, response);
+				}
+				return;
+			}
+		}
+		chain.doFilter(request, response);
+	}
+
+}

--- a/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/observability/package-info.java
+++ b/spring-ai-agentcore-runtime-starter/src/main/java/org/springaicommunity/agentcore/observability/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OTel baggage propagation support for AgentCore Runtime.
+ *
+ * <p>
+ * Injects {@code session.id} into OTel Baggage from the AgentCore session header,
+ * enabling downstream trace correlation and span enrichment.
+ */
+package org.springaicommunity.agentcore.observability;

--- a/spring-ai-agentcore-runtime-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-ai-agentcore-runtime-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 org.springaicommunity.agentcore.autoconfigure.AgentCoreAutoConfiguration
+org.springaicommunity.agentcore.observability.AgentCoreBaggagePropagationAutoConfiguration

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/observability/AgentCoreBaggagePropagationAutoConfigurationTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/observability/AgentCoreBaggagePropagationAutoConfigurationTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.observability;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.core.Ordered;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AgentCoreBaggagePropagationAutoConfiguration}.
+ *
+ * @author Vaquar Khan
+ */
+class AgentCoreBaggagePropagationAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(AgentCoreBaggagePropagationAutoConfiguration.class));
+
+	@Test
+	@DisplayName("Should register filter when OTel Baggage is on classpath")
+	void shouldRegisterFilterWhenOtelPresent() {
+		this.contextRunner.run((context) -> {
+			assertThat(context).hasBean("agentCoreSessionBaggageFilter");
+			assertThat(context).hasSingleBean(FilterRegistrationBean.class);
+		});
+	}
+
+	@Test
+	@DisplayName("Should not register filter when explicitly disabled")
+	void shouldNotRegisterFilterWhenDisabled() {
+		this.contextRunner.withPropertyValues("spring.ai.agentcore.baggage.enabled=false")
+			.run((context) -> assertThat(context).doesNotHaveBean(FilterRegistrationBean.class));
+	}
+
+	@Test
+	@DisplayName("Should register filter when property is explicitly true")
+	void shouldRegisterFilterWhenExplicitlyEnabled() {
+		this.contextRunner.withPropertyValues("spring.ai.agentcore.baggage.enabled=true")
+			.run((context) -> assertThat(context).hasSingleBean(FilterRegistrationBean.class));
+	}
+
+	@Test
+	@DisplayName("Filter registration should target /invocations URL pattern")
+	@SuppressWarnings("unchecked")
+	void shouldTargetInvocationsUrlPattern() {
+		this.contextRunner.run((context) -> {
+			FilterRegistrationBean<AgentCoreSessionBaggageFilter> registration = context
+				.getBean("agentCoreSessionBaggageFilter", FilterRegistrationBean.class);
+			assertThat(registration.getUrlPatterns()).containsExactly("/invocations");
+		});
+	}
+
+	@Test
+	@DisplayName("Filter should have high precedence order")
+	@SuppressWarnings("unchecked")
+	void shouldHaveHighPrecedenceOrder() {
+		this.contextRunner.run((context) -> {
+			FilterRegistrationBean<AgentCoreSessionBaggageFilter> registration = context
+				.getBean("agentCoreSessionBaggageFilter", FilterRegistrationBean.class);
+			assertThat(registration.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE + 10);
+		});
+	}
+
+}

--- a/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/observability/AgentCoreSessionBaggageFilterTests.java
+++ b/spring-ai-agentcore-runtime-starter/src/test/java/org/springaicommunity/agentcore/observability/AgentCoreSessionBaggageFilterTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.observability;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.opentelemetry.api.baggage.Baggage;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link AgentCoreSessionBaggageFilter}.
+ *
+ * @author Vaquar Khan
+ */
+class AgentCoreSessionBaggageFilterTests {
+
+	private final AgentCoreSessionBaggageFilter filter = new AgentCoreSessionBaggageFilter();
+
+	@Test
+	@DisplayName("Should set session.id in baggage when session header is present")
+	void shouldSetBaggageWhenHeaderPresent() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("X-Amzn-Bedrock-AgentCore-Runtime-Session-Id", "test-session-123");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		AtomicReference<String> capturedBaggage = new AtomicReference<>();
+		FilterChain chain = (req, res) -> capturedBaggage
+			.set(Baggage.current().getEntryValue(AgentCoreSessionBaggageFilter.BAGGAGE_KEY));
+
+		this.filter.doFilter(request, response, chain);
+
+		assertThat(capturedBaggage.get()).isEqualTo("test-session-123");
+	}
+
+	@Test
+	@DisplayName("Should not set baggage when session header is missing")
+	void shouldNotSetBaggageWhenHeaderMissing() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		AtomicReference<String> capturedBaggage = new AtomicReference<>();
+		FilterChain chain = (req, res) -> capturedBaggage
+			.set(Baggage.current().getEntryValue(AgentCoreSessionBaggageFilter.BAGGAGE_KEY));
+
+		this.filter.doFilter(request, response, chain);
+
+		assertThat(capturedBaggage.get()).isNull();
+	}
+
+	@Test
+	@DisplayName("Should not set baggage when session header is blank")
+	void shouldNotSetBaggageWhenHeaderBlank() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("X-Amzn-Bedrock-AgentCore-Runtime-Session-Id", "   ");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		AtomicReference<String> capturedBaggage = new AtomicReference<>();
+		FilterChain chain = (req, res) -> capturedBaggage
+			.set(Baggage.current().getEntryValue(AgentCoreSessionBaggageFilter.BAGGAGE_KEY));
+
+		this.filter.doFilter(request, response, chain);
+
+		assertThat(capturedBaggage.get()).isNull();
+	}
+
+	@Test
+	@DisplayName("Baggage scope should be closed after filter chain completes")
+	void shouldCloseBaggageScopeAfterChain() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("X-Amzn-Bedrock-AgentCore-Runtime-Session-Id", "scoped-session");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain chain = mock(FilterChain.class);
+
+		this.filter.doFilter(request, response, chain);
+
+		then(chain).should().doFilter(request, response);
+		// After filter completes, baggage should not leak
+		assertThat(Baggage.current().getEntryValue(AgentCoreSessionBaggageFilter.BAGGAGE_KEY)).isNull();
+	}
+
+	@Test
+	@DisplayName("Should preserve existing baggage entries")
+	void shouldPreserveExistingBaggage() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("X-Amzn-Bedrock-AgentCore-Runtime-Session-Id", "my-session");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		// Set up pre-existing baggage
+		Baggage existingBaggage = Baggage.builder().put("existing.key", "existing-value").build();
+
+		AtomicReference<String> capturedExisting = new AtomicReference<>();
+		AtomicReference<String> capturedSession = new AtomicReference<>();
+		FilterChain chain = (req, res) -> {
+			capturedExisting.set(Baggage.current().getEntryValue("existing.key"));
+			capturedSession.set(Baggage.current().getEntryValue(AgentCoreSessionBaggageFilter.BAGGAGE_KEY));
+		};
+
+		try (var ignored = existingBaggage.makeCurrent()) {
+			this.filter.doFilter(request, response, chain);
+		}
+
+		assertThat(capturedSession.get()).isEqualTo("my-session");
+		assertThat(capturedExisting.get()).isEqualTo("existing-value");
+	}
+
+}


### PR DESCRIPTION
Read X-Amzn-Bedrock-AgentCore-Runtime-Session-Id from inbound requests and inject into OTel Baggage as session.id. This enables downstream services to receive session context via W3C baggage header, and completes the circuit for SessionBaggageSpanProcessor in the OTel extension (PR #112) which reads session.id from baggage.

- AgentCoreSessionBaggageFilter: servlet filter that sets baggage
- AgentCoreBaggagePropagationAutoConfiguration: activates only when OTel API is on classpath, targets /invocations only
- Disableable via spring.ai.agentcore.baggage.enabled=false
- 10 tests covering filter behavior and auto-configuration

Closes #71 (baggage propagation component)
Related: #72, #112