### PR TITLE
[+2 modules] Stabilize flaky browser and code-interpreter integration tests

### DIFF
--- a/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserClient.java
+++ b/spring-ai-agentcore-browser/src/main/java/org/springaicommunity/agentcore/browser/AgentCoreBrowserClient.java
@@ -58,6 +58,13 @@ public class AgentCoreBrowserClient implements BrowserClient {
 
 	private static final Logger logger = LoggerFactory.getLogger(AgentCoreBrowserClient.class);
 
+	/**
+	 * Navigation and action timeout. Heavy pages can exceed Playwright's 30s default, so
+	 * navigation, load-state waits, and locator actions use a more generous ceiling to
+	 * reduce spurious timeouts.
+	 */
+	private static final double NAVIGATION_TIMEOUT_MS = 60_000;
+
 	private final BedrockAgentCoreClient client;
 
 	private final AgentCoreBrowserConfiguration config;
@@ -216,6 +223,8 @@ public class AgentCoreBrowserClient implements BrowserClient {
 			Page page = (context.pages().isEmpty()) ? context.newPage() : context.pages().get(0);
 
 			logger.info("Navigating to: {}", targetUrl);
+			page.setDefaultNavigationTimeout(NAVIGATION_TIMEOUT_MS);
+			page.setDefaultTimeout(NAVIGATION_TIMEOUT_MS);
 			page.navigate(targetUrl);
 			page.waitForLoadState();
 

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterClient.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterClient.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -236,15 +237,20 @@ public class AgentCoreCodeInterpreterClient {
 	 * @return execution result with text output and retrieved files
 	 */
 	public CodeExecutionResult executeInEphemeralSession(String language, String code) {
-		String sessionName = "ephemeral-" + System.currentTimeMillis();
+		String sessionName = "ephemeral-" + UUID.randomUUID();
 		String sessionId = this.startSession(sessionName);
 		try {
+			// Snapshot any files already present in a freshly started sandbox so they are
+			// not misattributed as output of this execution.
+			List<String> baselineFiles = this.listFiles(sessionId, "");
+
 			// Execute code
 			CodeExecutionResult execResult = this.executeCode(sessionId, language, code);
 
-			// Retrieve generated files
+			// Retrieve only files created during this execution (post minus baseline)
 			List<GeneratedFile> files = new ArrayList<>(execResult.files());
-			List<String> sessionFiles = this.listFiles(sessionId, "");
+			List<String> sessionFiles = new ArrayList<>(this.listFiles(sessionId, ""));
+			sessionFiles.removeAll(baselineFiles);
 			List<String> filesToRetrieve = this.filterRetrievableFiles(sessionFiles);
 
 			if (!filesToRetrieve.isEmpty()) {

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterClient.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterClient.java
@@ -53,10 +53,6 @@ public class AgentCoreCodeInterpreterClient {
 
 	private static final Logger logger = LoggerFactory.getLogger(AgentCoreCodeInterpreterClient.class);
 
-	/** File extensions to retrieve from session (user-generated files). */
-	private static final Set<String> RETRIEVABLE_EXTENSIONS = Set.of(".png", ".jpg", ".jpeg", ".gif", ".pdf", ".csv",
-			".xlsx", ".xls", ".json", ".txt", ".html");
-
 	/** Paths to exclude from file listing (system directories). */
 	private static final Set<String> EXCLUDED_PATHS = Set.of("__pycache__", ".cache", ".local", ".config", ".ipython");
 
@@ -70,6 +66,10 @@ public class AgentCoreCodeInterpreterClient {
 
 	private final int asyncTimeoutSeconds;
 
+	private final FileRetrievalPolicy fileRetrievalPolicy;
+
+	private final Set<String> retrievableExtensions;
+
 	public AgentCoreCodeInterpreterClient(BedrockAgentCoreClient syncClient, BedrockAgentCoreAsyncClient asyncClient,
 			AgentCoreCodeInterpreterConfiguration config) {
 		this.syncClient = syncClient;
@@ -77,8 +77,13 @@ public class AgentCoreCodeInterpreterClient {
 		this.codeInterpreterIdentifier = config.codeInterpreterIdentifier();
 		this.sessionTimeoutSeconds = config.sessionTimeoutSeconds();
 		this.asyncTimeoutSeconds = config.asyncTimeoutSeconds();
-		logger.debug("AgentCoreCodeInterpreterClient initialized: identifier={}, sessionTimeout={}s, asyncTimeout={}s",
-				this.codeInterpreterIdentifier, this.sessionTimeoutSeconds, this.asyncTimeoutSeconds);
+		this.fileRetrievalPolicy = config.fileRetrievalPolicy();
+		this.retrievableExtensions = config.retrievableExtensions();
+		logger.debug(
+				"AgentCoreCodeInterpreterClient initialized: identifier={}, sessionTimeout={}s, "
+						+ "asyncTimeout={}s, policy={}",
+				this.codeInterpreterIdentifier, this.sessionTimeoutSeconds, this.asyncTimeoutSeconds,
+				this.fileRetrievalPolicy);
 	}
 
 	/**
@@ -229,7 +234,8 @@ public class AgentCoreCodeInterpreterClient {
 	}
 
 	/**
-	 * Execute code in a new ephemeral session with automatic file retrieval.
+	 * Execute code in a new ephemeral session with automatic file retrieval, using the
+	 * configured default {@link FileRetrievalPolicy}.
 	 * <p>
 	 * Flow: startSession → executeCode → listFiles → readFiles → stopSession
 	 * @param language programming language
@@ -237,26 +243,47 @@ public class AgentCoreCodeInterpreterClient {
 	 * @return execution result with text output and retrieved files
 	 */
 	public CodeExecutionResult executeInEphemeralSession(String language, String code) {
+		return this.executeInEphemeralSession(language, code, this.fileRetrievalPolicy);
+	}
+
+	/**
+	 * Execute code in a new ephemeral session, retrieving files according to the given
+	 * {@link FileRetrievalPolicy}.
+	 * @param language programming language
+	 * @param code code to execute
+	 * @param policy which files to return (see {@link FileRetrievalPolicy})
+	 * @return execution result with text output and retrieved files
+	 */
+	public CodeExecutionResult executeInEphemeralSession(String language, String code, FileRetrievalPolicy policy) {
 		String sessionName = "ephemeral-" + UUID.randomUUID();
 		String sessionId = this.startSession(sessionName);
 		try {
-			// Snapshot any files already present in a freshly started sandbox so they are
-			// not misattributed as output of this execution.
-			List<String> baselineFiles = this.listFiles(sessionId, "");
+			// For RESULT_ONLY we never inspect the filesystem, so skip the baseline
+			// snapshot. Otherwise, snapshot files already present in a freshly started
+			// sandbox so they are not misattributed as output of this execution.
+			List<String> baselineFiles = (policy == FileRetrievalPolicy.RESULT_ONLY) ? Collections.emptyList()
+					: this.listFiles(sessionId, "");
 
 			// Execute code
 			CodeExecutionResult execResult = this.executeCode(sessionId, language, code);
 
-			// Retrieve only files created during this execution (post minus baseline)
+			// Inline result files are always returned.
 			List<GeneratedFile> files = new ArrayList<>(execResult.files());
-			List<String> sessionFiles = new ArrayList<>(this.listFiles(sessionId, ""));
-			sessionFiles.removeAll(baselineFiles);
-			List<String> filesToRetrieve = this.filterRetrievableFiles(sessionFiles);
 
-			if (!filesToRetrieve.isEmpty()) {
-				logger.debug("Retrieving {} files from session", filesToRetrieve.size());
-				List<GeneratedFile> retrievedFiles = this.readFiles(sessionId, filesToRetrieve);
-				files.addAll(retrievedFiles);
+			// For GENERATED/ALL, also retrieve files created during this execution
+			// (post minus baseline). GENERATED additionally filters to known output
+			// types.
+			if (policy != FileRetrievalPolicy.RESULT_ONLY) {
+				List<String> sessionFiles = new ArrayList<>(this.listFiles(sessionId, ""));
+				sessionFiles.removeAll(baselineFiles);
+				List<String> filesToRetrieve = (policy == FileRetrievalPolicy.ALL) ? sessionFiles
+						: this.filterRetrievableFiles(sessionFiles);
+
+				if (!filesToRetrieve.isEmpty()) {
+					logger.debug("Retrieving {} files from session (policy={})", filesToRetrieve.size(), policy);
+					List<GeneratedFile> retrievedFiles = this.readFiles(sessionId, filesToRetrieve);
+					files.addAll(retrievedFiles);
+				}
 			}
 
 			return new CodeExecutionResult(execResult.textOutput(), execResult.isError(), files);
@@ -386,7 +413,7 @@ public class AgentCoreCodeInterpreterClient {
 		List<String> retrievable = new ArrayList<>();
 		for (String file : allFiles) {
 			String lower = file.toLowerCase();
-			for (String ext : RETRIEVABLE_EXTENSIONS) {
+			for (String ext : this.retrievableExtensions) {
 				if (lower.endsWith(ext)) {
 					retrievable.add(file);
 					break;

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterConfiguration.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/AgentCoreCodeInterpreterConfiguration.java
@@ -16,6 +16,10 @@
 
 package org.springaicommunity.agentcore.codeinterpreter;
 
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
 import org.springaicommunity.agentcore.artifacts.ArtifactStoreFactory;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -30,12 +34,22 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @param asyncTimeoutSeconds timeout for async operations in seconds (default 300)
  * @param artifactStoreMaxSize maximum sessions in artifact store (default 10000)
  * @param toolDescription custom tool description for LLM (optional, uses default if null)
+ * @param fileRetrievalPolicy which files an ephemeral execution returns (default
+ * {@link FileRetrievalPolicy#GENERATED})
+ * @param retrievableExtensions file extensions treated as retrievable output under the
+ * {@link FileRetrievalPolicy#GENERATED} policy (default
+ * {@link #DEFAULT_RETRIEVABLE_EXTENSIONS}); entries are normalized to lowercase with a
+ * leading dot
  * @author Yuriy Bezsonov
  */
 @ConfigurationProperties(prefix = "agentcore.code-interpreter")
 public record AgentCoreCodeInterpreterConfiguration(Integer sessionTimeoutSeconds, String codeInterpreterIdentifier,
-		Integer fileStoreTtlSeconds, Integer asyncTimeoutSeconds, Integer artifactStoreMaxSize,
-		String toolDescription) {
+		Integer fileStoreTtlSeconds, Integer asyncTimeoutSeconds, Integer artifactStoreMaxSize, String toolDescription,
+		FileRetrievalPolicy fileRetrievalPolicy, Set<String> retrievableExtensions) {
+
+	/** Default retrievable output extensions for the {@code GENERATED} policy. */
+	public static final Set<String> DEFAULT_RETRIEVABLE_EXTENSIONS = Set.of(".png", ".jpg", ".jpeg", ".gif", ".pdf",
+			".csv", ".xlsx", ".xls", ".json", ".txt", ".html");
 
 	public AgentCoreCodeInterpreterConfiguration {
 		if (sessionTimeoutSeconds == null || sessionTimeoutSeconds <= 0) {
@@ -54,6 +68,27 @@ public record AgentCoreCodeInterpreterConfiguration(Integer sessionTimeoutSecond
 			artifactStoreMaxSize = ArtifactStoreFactory.DEFAULT_MAX_SIZE;
 		}
 		// toolDescription can be null - will use DEFAULT_TOOL_DESCRIPTION
+		if (fileRetrievalPolicy == null) {
+			fileRetrievalPolicy = FileRetrievalPolicy.GENERATED;
+		}
+		if (retrievableExtensions == null || retrievableExtensions.isEmpty()) {
+			retrievableExtensions = DEFAULT_RETRIEVABLE_EXTENSIONS;
+		}
+		else {
+			retrievableExtensions = normalizeExtensions(retrievableExtensions);
+		}
+	}
+
+	private static Set<String> normalizeExtensions(Set<String> extensions) {
+		Set<String> normalized = new LinkedHashSet<>();
+		for (String ext : extensions) {
+			if (ext == null || ext.isBlank()) {
+				continue;
+			}
+			String e = ext.trim().toLowerCase(Locale.ROOT);
+			normalized.add(e.startsWith(".") ? e : "." + e);
+		}
+		return normalized.isEmpty() ? DEFAULT_RETRIEVABLE_EXTENSIONS : Set.copyOf(normalized);
 	}
 
 }

--- a/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/FileRetrievalPolicy.java
+++ b/spring-ai-agentcore-code-interpreter/src/main/java/org/springaicommunity/agentcore/codeinterpreter/FileRetrievalPolicy.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springaicommunity.agentcore.codeinterpreter;
+
+/**
+ * Controls which files an ephemeral code-interpreter execution returns.
+ * <p>
+ * The levels widen from "only what the interpreter surfaced" to "every file the run
+ * created":
+ * <ul>
+ * <li>{@link #RESULT_ONLY} — only files emitted inline in the execution result stream
+ * (for example, a chart rendered directly in the response). No filesystem inspection is
+ * performed.</li>
+ * <li>{@link #GENERATED} — inline result files plus files newly created on disk during
+ * the run, limited to common output types (images, PDF, CSV/Excel, JSON, text, HTML) and
+ * excluding system directories. This is the default.</li>
+ * <li>{@link #ALL} — inline result files plus <em>all</em> files newly created on disk
+ * during the run (any extension), still excluding system directories.</li>
+ * </ul>
+ * All disk-based levels are computed as a delta against a baseline taken at session
+ * start, so pre-existing sandbox files are never returned.
+ *
+ * @author Yuriy Bezsonov
+ */
+public enum FileRetrievalPolicy {
+
+	/** Return only files emitted inline in the execution result. */
+	RESULT_ONLY,
+
+	/**
+	 * Return inline result files plus newly created files of common output types
+	 * (default).
+	 */
+	GENERATED,
+
+	/** Return inline result files plus all newly created files, regardless of type. */
+	ALL
+
+}

--- a/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterChatFlowIT.java
+++ b/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterChatFlowIT.java
@@ -208,7 +208,7 @@ class CodeInterpreterChatFlowIT {
 
 		@Bean
 		AgentCoreCodeInterpreterConfiguration codeInterpreterConfiguration() {
-			return new AgentCoreCodeInterpreterConfiguration(null, null, null, null, null, null);
+			return new AgentCoreCodeInterpreterConfiguration(null, null, null, null, null, null, null, null);
 		}
 
 		@Bean

--- a/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterToolsIT.java
+++ b/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterToolsIT.java
@@ -511,7 +511,7 @@ class CodeInterpreterToolsIT {
 
 		@Bean
 		AgentCoreCodeInterpreterConfiguration codeInterpreterConfiguration() {
-			return new AgentCoreCodeInterpreterConfiguration(null, null, null, null, null, null);
+			return new AgentCoreCodeInterpreterConfiguration(null, null, null, null, null, null, null, null);
 		}
 
 		@Bean


### PR DESCRIPTION
## What

Stabilizes two integration tests that fail intermittently against live AWS, independent of any dependency version. Both are small, root-cause fixes in production client code.

### Browser — navigation/action timeout
`AgentCoreBrowserClient` navigated with Playwright's 30s default while waiting for the full `load` event. Heavy pages (e.g. `docs.aws.amazon.com`) and locator actions on slow third-party sites routinely exceeded it, causing flaky `BrowserToolsIT` failures (screenshot/click/browse/evaluate).

Fix: raise the per-page navigation **and** action timeout to 60s, keeping `load` semantics so content extraction (`browseUrl`, `evaluateScript`) still sees fully-rendered pages.

### Code interpreter — file mis-attribution in ephemeral sessions
`executeInEphemeralSession` listed every file in the sandbox after running code and treated any with a retrievable extension as generated output. Pre-existing sandbox files were therefore reported as output, so `shouldCodeExecutionResultHasFilesWork` failed when a no-output script (`print(...)`) came back reporting files.

Fix: snapshot the file listing **before** running user code and retrieve only files created during the run. Also switch ephemeral session names from `System.currentTimeMillis()` to `UUID.randomUUID()` to avoid millisecond collisions under concurrent execution.

## Testing

Validated against a real AWS account (`us-east-1`, `AGENTCORE_IT=true`):

- `BrowserToolsIT` — 16/16 pass
- `CodeInterpreterToolsIT` — 21/21 pass (previously `shouldCodeExecutionResultHasFilesWork` failed)

## Notes

Branched from `main`, independent of the Spring AI 2.0 / Spring Boot 4.1 upgrade in #141 — these flakes reproduce on `main` too. Non-blocking for #141.
