### PR TITLE
[docs] Clarify integration testing and fix stale references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,22 @@ mvn spring-javaformat:apply rewrite:run -pl <module>
 # Full build (CI does this — rarely needed locally)
 mvn clean verify
 
-# Integration tests (requires AWS credentials)
-AGENTCORE_IT=true mvn verify -pl spring-ai-agentcore-memory
+# Integration tests (requires AWS credentials in us-east-1)
+# ITs self-provision and tear down their own AWS resources; no pre-existing
+# resources are needed for the default path.
+AGENTCORE_IT=true AWS_REGION=us-east-1 mvn verify -pl spring-ai-agentcore-memory
+
+# Run integration tests across all modules
+AGENTCORE_IT=true AWS_REGION=us-east-1 mvn clean verify
 ```
+
+> **Integration test prerequisites**
+> - AWS credentials with AgentCore access, in **us-east-1** (the browser ITs assert this region).
+> - The browser module ITs need Playwright/Chromium (downloaded automatically on first run).
+> - The default memory IT (`AgentCoreMemoryE2EIT`) **creates and deletes** its own memory and
+>   long-term strategies — it needs only `AGENTCORE_IT=true` plus credentials, no pre-existing IDs.
+> - After switching git branches, run `mvn clean ...` — the OpenRewrite recipe module compiles
+>   test sources incrementally and stale `target/` output from another branch can break the build.
 
 ## Code Conventions
 
@@ -96,10 +109,15 @@ This fixes: import ordering, `this.` qualifiers, lambda formatting, inner type p
 
 ## Integration Test Environment Variables
 
+Most ITs self-provision their AWS resources and need only `AGENTCORE_IT=true` plus
+credentials. The variables below are **only** for the optional `AgentCoreMemoryEnvIT`
+path, which runs against a pre-existing memory instead of creating one (see
+`scripts/it-memory.sh`, which discovers and exports them automatically):
+
 ```bash
 AGENTCORE_MEMORY_MEMORY_ID=<memory-id>
-AGENTCORE_MEMORY_LONG_TERM_SEMANTIC_STRATEGY_ID=SemanticFacts-xxxxx
-AGENTCORE_MEMORY_LONG_TERM_USER_PREFERENCE_STRATEGY_ID=UserPreferences-xxxxx
+AGENTCORE_MEMORY_LONG_TERM_SEMANTIC_FACTS_STRATEGY_ID=SemanticFacts-xxxxx
+AGENTCORE_MEMORY_LONG_TERM_USER_PREFERENCES_STRATEGY_ID=UserPreferences-xxxxx
 AGENTCORE_MEMORY_LONG_TERM_SUMMARY_STRATEGY_ID=ConversationSummary-xxxxx
 AGENTCORE_MEMORY_LONG_TERM_EPISODIC_STRATEGY_ID=EpisodicMemory-xxxxx
 ```

--- a/spring-ai-agentcore-browser/README.md
+++ b/spring-ai-agentcore-browser/README.md
@@ -25,7 +25,7 @@ Add the BOM and dependency:
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agentcore-bom</artifactId>
-            <version>${version}</version>  <!-- Use latest: 1.0.0-RC2, 1.0.0-RC3, etc. -->
+            <version>1.0.0</version>  <!-- or the latest release -->
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/spring-ai-agentcore-memory/README.md
+++ b/spring-ai-agentcore-memory/README.md
@@ -286,7 +286,7 @@ void deleteByConversationId(String conversationId);
 
 ## Testing
 
-See [DEV.md](../DEV.md) for testing instructions.
+See the [Build &amp; Test](../AGENTS.md#build--test) and [Integration Test Environment Variables](../AGENTS.md#integration-test-environment-variables) sections in `AGENTS.md` for testing instructions.
 
 ## License
 


### PR DESCRIPTION
## What

Documentation-only fixes for issues that made the integration-test workflow confusing or wrong. No code changes.

### Wrong env var names (actively misleading)
`AGENTS.md` listed `AGENTCORE_MEMORY_LONG_TERM_SEMANTIC_STRATEGY_ID` and `..._USER_PREFERENCE_STRATEGY_ID`, but the code (`AgentCoreMemoryEnvIT`) and `scripts/it-memory.sh` use `..._SEMANTIC_FACTS_STRATEGY_ID` and `..._USER_PREFERENCES_STRATEGY_ID`. Following the docs makes the Env IT silently skip.

### Unclear testing instructions
The env var block read as a blanket IT requirement. Clarified that the default ITs (e.g. `AgentCoreMemoryE2EIT`) **self-provision and tear down** their own AWS resources and need only `AGENTCORE_IT=true` + credentials; those variables are only for the optional pre-existing-memory path.

Also documented previously-unstated prerequisites:
- ITs require **us-east-1** (browser ITs assert the region).
- Browser ITs need Playwright/Chromium.
- Run `mvn clean` after switching branches (the OpenRewrite recipe module breaks on stale cross-branch `target/` output).

### Broken link
`spring-ai-agentcore-memory/README.md` pointed to `../DEV.md`, which does not exist. Now links to the `AGENTS.md` Build & Test sections.

### Stale version reference
`spring-ai-agentcore-browser/README.md` BOM example referenced pre-release RCs (`1.0.0-RC2`, `1.0.0-RC3`); updated to `1.0.0` GA.

## Notes

Branched from `main`. Touches different lines than #141, so it does not conflict. Non-blocking for #141.
