### PR TITLE
build: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,37 @@
+# Normalize all text files to LF on commit, matching CI (Linux).
+* text=auto eol=lf
+
+# Source and config
+*.java text eol=lf
+*.xml text eol=lf
+*.properties text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.txt text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.sql text eol=lf
+*.tf text eol=lf
+*.http text eol=lf
+
+# Shell scripts
+*.sh text eol=lf
+
+# Windows scripts keep CRLF
+*.cmd text eol=crlf
+*.bat text eol=crlf
+
+# Binaries
+*.jar binary
+*.png binary
+*.gif binary
+*.ico binary
+*.jpg binary
+*.jpeg binary
+*.zip binary
+*.gz binary
+*.tar binary


### PR DESCRIPTION
The repo had no .gitattributes. CI runs on Linux (LF), but Windows with the default core.autocrlf=true checks out CRLF. This caused mvn rewrite:dryRun to report ~140 spurious whole-file diffs (only EOL changes) and risked accidental CRLF commits from Windows contributors.

Add .gitattributes normalizing all text to eol=lf (matching CI), keeping *.cmd/*.bat as CRLF, and marking common binaries.

No source code changed. Build hygiene only.

Fixes #155