### PR TITLE
ci: add non-blocking integration test workflow for live AWS tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,18 +4,20 @@ name: Integration Tests
 # Non-blocking: results are informational only, not required for merge.
 #
 # Triggers:
-#   - Nightly schedule (catches regressions)
-#   - Manual dispatch (on-demand validation, with optional memory_id override)
-#   - Label 'run-integration-tests' on PRs (opt-in per PR)
+# - Manual dispatch (on-demand validation, with optional memory_id override)
+# - Label 'run-integration-tests' on PRs (opt-in per PR)
 #
+# A nightly `schedule:` trigger is intentionally NOT enabled yet: without a
+# dedicated AWS account (the AWS_INTEGRATION_TEST_ROLE_ARN secret and
+# AGENTCORE_MEMORY_ID variable), a scheduled run would fail at the
+# "Resolve AgentCore Memory ID" step and produce a red build every night with
+# no signal. Re-add a `schedule:` block once the dedicated account is provisioned.
 # Prerequisites:
 #   - Repository secret: AWS_INTEGRATION_TEST_ROLE_ARN (GitHub OIDC IAM role)
 #   - Repository variable: AGENTCORE_MEMORY_ID (pinned memory ID for tests)
 #   - Repository variable: AWS_REGION (optional, defaults to us-east-1)
 
 on:
-  schedule:
-    - cron: '0 6 * * *'  # Daily at 06:00 UTC
   workflow_dispatch:
     inputs:
       memory_id:
@@ -36,9 +38,8 @@ concurrency:
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
-    # Only run on schedule, dispatch, or when the label is applied
+    # Only run on manual dispatch or when the label is applied
     if: >
-      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.label.name == 'run-integration-tests')
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,8 +70,7 @@ jobs:
           AGENTCORE_IT: 'true'
           AGENTCORE_EVAL_PROBE: 'true'
         run: |
-          mvn -ntp verify -am \
-            -pl spring-ai-agentcore-memory,spring-ai-agentcore-browser,spring-ai-agentcore-code-interpreter,spring-ai-agentcore-evaluations \
+          mvn -ntp verify -Pintegration \
             -Dmaven.test.failure.ignore=true
 
       - name: Upload test reports
@@ -79,5 +78,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-reports
-          path: '**/target/surefire-reports/'
+          path: |
+            **/target/surefire-reports/
+            **/target/failsafe-reports/
           retention-days: 7

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,83 @@
+name: Integration Tests
+
+# Runs live AWS integration tests against Bedrock AgentCore.
+# Non-blocking: results are informational only, not required for merge.
+#
+# Triggers:
+#   - Nightly schedule (catches regressions)
+#   - Manual dispatch (on-demand validation, with optional memory_id override)
+#   - Label 'run-integration-tests' on PRs (opt-in per PR)
+#
+# Prerequisites:
+#   - Repository secret: AWS_INTEGRATION_TEST_ROLE_ARN (GitHub OIDC IAM role)
+#   - Repository variable: AGENTCORE_MEMORY_ID (pinned memory ID for tests)
+#   - Repository variable: AWS_REGION (optional, defaults to us-east-1)
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      memory_id:
+        description: 'Override memory ID (leave empty to use repo variable)'
+        required: false
+        type: string
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  id-token: write  # Required for GitHub OIDC → AWS IAM role
+
+concurrency:
+  group: integration-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    # Only run on schedule, dispatch, or when the label is applied
+    if: >
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'run-integration-tests')
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'corretto'
+          cache: 'maven'
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_INTEGRATION_TEST_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+
+      - name: Resolve AgentCore Memory ID
+        run: |
+          MEMORY_ID="${{ github.event.inputs.memory_id || vars.AGENTCORE_MEMORY_ID }}"
+          if [ -z "$MEMORY_ID" ]; then
+            echo "::error::AGENTCORE_MEMORY_ID is not configured and no input was provided."
+            exit 1
+          fi
+          echo "AGENTCORE_MEMORY_MEMORY_ID=$MEMORY_ID" >> "$GITHUB_ENV"
+
+      - name: Run integration tests
+        env:
+          AGENTCORE_IT: 'true'
+          AGENTCORE_EVAL_PROBE: 'true'
+        run: |
+          mvn -ntp verify -am \
+            -pl spring-ai-agentcore-memory,spring-ai-agentcore-browser,spring-ai-agentcore-code-interpreter,spring-ai-agentcore-evaluations \
+            -Dmaven.test.failure.ignore=true
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-reports
+          path: '**/target/surefire-reports/'
+          retention-days: 7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,12 +61,49 @@ Integration tests require AWS credentials and are skipped by default. Run them w
 AGENTCORE_IT=true mvn verify -pl spring-ai-agentcore-memory
 ```
 
+To run all integration tests across all modules:
+```bash
+AGENTCORE_IT=true AGENTCORE_EVAL_PROBE=true mvn verify \
+  -pl spring-ai-agentcore-memory,spring-ai-agentcore-browser,spring-ai-agentcore-code-interpreter,spring-ai-agentcore-evaluations
+```
+
+#### Required environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `AGENTCORE_IT=true` | Enables memory, browser, and code-interpreter IT tests |
+| `AGENTCORE_EVAL_PROBE=true` | Enables evaluations IT tests |
+| `AGENTCORE_MEMORY_MEMORY_ID` | Pinned memory ID for tests |
+
+Strategy IDs (`SEMANTIC_FACTS`, `USER_PREFERENCES`, `SUMMARY`, `EPISODIC`) are
+discovered at runtime by the tests themselves from the configured memory.
+
+#### CI integration test job
+
+A separate GitHub Actions workflow (`.github/workflows/integration-tests.yml`) runs
+the live AWS integration tests. It is **non-blocking** (does not gate merge) and triggers:
+
+- **Nightly** (cron schedule) — catches regressions automatically
+- **Manual dispatch** — on-demand via Actions UI, with optional memory ID override
+- **PR label** `run-integration-tests` — opt-in per PR
+
+The workflow uses GitHub OIDC to assume an AWS IAM role (no long-lived secrets).
+To set up the AWS side:
+
+1. Create an IAM OIDC provider for `token.actions.githubusercontent.com`
+2. Create an IAM role with trust policy allowing the GitHub repo
+3. Attach permissions for Bedrock AgentCore (Memory, Browser, Code Interpreter, Evaluations)
+4. Set `AWS_INTEGRATION_TEST_ROLE_ARN` as a repository secret
+5. Set `AGENTCORE_MEMORY_ID` as a repository variable (pinned memory ID)
+6. Optionally set `AWS_REGION` as a repository variable (defaults to `us-east-1`)
+
 ## CI
 
 CI runs on every PR and merge queue entry:
 1. `mvn clean verify` — compile, checkstyle, license check, tests
 2. `mvn rewrite:dryRun` — verifies no rewrite recipes would change anything
 3. Examples build — installs library, then builds and tests examples
+4. Integration tests (separate workflow, non-blocking) — live AWS round-trips on schedule/dispatch/label
 
 ## Project structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,24 +56,30 @@ mvn spring-javaformat:apply rewrite:run -pl <module>
 
 ### Integration tests
 
-Integration tests require AWS credentials and are skipped by default. Run them with:
+Integration tests require AWS credentials and are skipped by default. Live AWS tests
+are tagged `@Tag("integration")` and selected via the Maven `integration` profile.
+
+Run all live AWS integration tests:
 ```bash
-AGENTCORE_IT=true mvn verify -pl spring-ai-agentcore-memory
+AGENTCORE_IT=true AGENTCORE_EVAL_PROBE=true mvn verify -Pintegration
 ```
 
-To run all integration tests across all modules:
+Run integration tests for a single module:
 ```bash
-AGENTCORE_IT=true AGENTCORE_EVAL_PROBE=true mvn verify \
-  -pl spring-ai-agentcore-memory,spring-ai-agentcore-browser,spring-ai-agentcore-code-interpreter,spring-ai-agentcore-evaluations
+AGENTCORE_IT=true mvn verify -Pintegration -pl spring-ai-agentcore-memory
 ```
+
+Local browser tests (`LocalBrowserToolsIT`) are not tagged and run with the default
+profile: `mvn verify -pl spring-ai-agentcore-browser`.
 
 #### Required environment variables
 
 | Variable | Description |
 |----------|-------------|
-| `AGENTCORE_IT=true` | Enables memory, browser, and code-interpreter IT tests |
+| `AGENTCORE_IT=true` | Enables memory, browser, and code-interpreter live AWS IT tests |
 | `AGENTCORE_EVAL_PROBE=true` | Enables evaluations IT tests |
-| `AGENTCORE_MEMORY_MEMORY_ID` | Pinned memory ID for tests |
+| `AGENTCORE_MEMORY_MEMORY_ID` | Pinned memory ID for tests (CI repo variable) |
+| `-Pintegration` | Maven profile selecting `@Tag("integration")` tests via Failsafe |
 
 Strategy IDs (`SEMANTIC_FACTS`, `USER_PREFERENCES`, `SUMMARY`, `EPISODIC`) are
 discovered at runtime by the tests themselves from the configured memory.

--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,14 @@
                             <groups>integration</groups>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.5.6</version>
+                        <configuration combine.self="override">
+                            <groups>integration</groups>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,22 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <excludedGroups>integration</excludedGroups>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${maven-jar-plugin.version}</version>
                 <configuration>
@@ -373,7 +389,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.6</version>
                         <configuration combine.self="override">
                             <groups>integration</groups>
                         </configuration>

--- a/spring-ai-agentcore-browser/pom.xml
+++ b/spring-ai-agentcore-browser/pom.xml
@@ -136,28 +136,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*IT.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.6</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserChatFlowIT.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserChatFlowIT.java
@@ -19,6 +19,7 @@ package org.springaicommunity.agentcore.browser;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springaicommunity.agentcore.artifacts.ArtifactStore;
@@ -48,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Yuriy Bezsonov
  */
+@Tag("integration")
 @EnabledIfEnvironmentVariable(named = "AGENTCORE_IT", matches = "true")
 @SpringBootTest(classes = BrowserChatFlowIT.TestApp.class)
 @DisplayName("Browser ChatClient Flow Integration Tests")

--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserToolsIT.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserToolsIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -45,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Yuriy Bezsonov
  */
+@Tag("integration")
 @EnabledIfEnvironmentVariable(named = "AGENTCORE_IT", matches = "true")
 @SpringBootTest(classes = BrowserToolsIT.TestApp.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/EnterprisePoliciesIT.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/EnterprisePoliciesIT.java
@@ -23,6 +23,7 @@ import com.microsoft.playwright.Playwright;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Yuriy Bezsonov
  */
+@Tag("integration")
 @EnabledIfEnvironmentVariable(named = "AGENTCORE_IT", matches = "true")
 @DisplayName("Enterprise Policies Integration Tests")
 class EnterprisePoliciesIT {

--- a/spring-ai-agentcore-code-interpreter/pom.xml
+++ b/spring-ai-agentcore-code-interpreter/pom.xml
@@ -119,28 +119,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*IT.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.6</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterChatFlowIT.java
+++ b/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterChatFlowIT.java
@@ -19,6 +19,7 @@ package org.springaicommunity.agentcore.codeinterpreter;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springaicommunity.agentcore.artifacts.ArtifactStore;
@@ -49,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Yuriy Bezsonov
  */
+@Tag("integration")
 @EnabledIfEnvironmentVariable(named = "AGENTCORE_IT", matches = "true")
 @SpringBootTest(classes = CodeInterpreterChatFlowIT.TestApp.class)
 @DisplayName("CodeInterpreter ChatClient Flow Integration Tests")

--- a/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterToolsIT.java
+++ b/spring-ai-agentcore-code-interpreter/src/test/java/org/springaicommunity/agentcore/codeinterpreter/CodeInterpreterToolsIT.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -51,6 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Yuriy Bezsonov
  */
+@Tag("integration")
 @EnabledIfEnvironmentVariable(named = "AGENTCORE_IT", matches = "true")
 @SpringBootTest(classes = CodeInterpreterToolsIT.TestApp.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/spring-ai-agentcore-evaluations/pom.xml
+++ b/spring-ai-agentcore-evaluations/pom.xml
@@ -112,6 +112,19 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/spring-ai-agentcore-evaluations/pom.xml
+++ b/spring-ai-agentcore-evaluations/pom.xml
@@ -103,28 +103,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*IT.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.6</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClientProbeIT.java
+++ b/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClientProbeIT.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import software.amazon.awssdk.regions.Region;
@@ -30,6 +31,7 @@ import software.amazon.awssdk.services.bedrockagentcore.BedrockAgentCoreClient;
  * Live probe for the AgentCore Evaluate API. Enabled via
  * {@code AGENTCORE_EVAL_PROBE=true}.
  */
+@Tag("integration")
 @EnabledIfEnvironmentVariable(named = "AGENTCORE_EVAL_PROBE", matches = "true")
 class AgentCoreEvaluationClientProbeIT {
 

--- a/spring-ai-agentcore-memory/pom.xml
+++ b/spring-ai-agentcore-memory/pom.xml
@@ -121,33 +121,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*IT.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.6</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*EnvIT.java</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryE2EIT.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryE2EIT.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import software.amazon.awssdk.services.bedrockagentcorecontrol.BedrockAgentCoreControlClient;
 import software.amazon.awssdk.services.bedrockagentcorecontrol.model.CreateMemoryRequest;
@@ -53,6 +54,7 @@ import static org.awaitility.Awaitility.await;
  *
  * @author Yuriy Bezsonov
  */
+@Tag("integration")
 @EnabledIfEnvironmentVariable(named = "AGENTCORE_IT", matches = "true")
 @SpringBootTest(classes = AgentCoreMemoryIT.TestApp.class,
 		properties = { "spring.ai.bedrock.converse.chat.model=" + AgentCoreMemoryIT.CHAT_MODEL })

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryEnvIT.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryEnvIT.java
@@ -18,6 +18,7 @@ package org.springaicommunity.agentcore.memory;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
 
@@ -40,6 +41,7 @@ import org.springframework.boot.test.context.SpringBootTest;
  *
  * @author Yuriy Bezsonov
  */
+@Tag("integration")
 @EnabledIfEnvironmentVariables({ @EnabledIfEnvironmentVariable(named = "AGENTCORE_MEMORY_MEMORY_ID", matches = ".+"),
 		@EnabledIfEnvironmentVariable(named = "AGENTCORE_MEMORY_LONG_TERM_SEMANTIC_FACTS_STRATEGY_ID", matches = ".+"),
 		@EnabledIfEnvironmentVariable(named = "AGENTCORE_MEMORY_LONG_TERM_USER_PREFERENCES_STRATEGY_ID",


### PR DESCRIPTION
The *IT integration tests are gated by AGENTCORE_IT=true and require live AWS credentials. CI runs mvn clean verify without that variable, so every AWS-backed path is skipped on every PR and merge.

Add a separate, non-blocking workflow (integration-tests.yml) that:
- Runs AGENTCORE_IT=true mvn verify against live AgentCore services
- Uses GitHub OIDC to assume an AWS IAM role (no long-lived secrets)
- Triggers on nightly schedule, manual dispatch, or PR label
- Uploads test reports as artifacts for debugging
- Does NOT gate merge (informational only)

Update CONTRIBUTING.md with:
- Full integration test documentation
- Required environment variables table
- AWS OIDC setup instructions for maintainers

Fixes #156