### PR TITLE
Fix Maven Central publishing and CI recipe resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: 'corretto'
           cache: 'maven'
       - name: Build with Maven
-        run: mvn -ntp clean verify
+        run: mvn -ntp clean install
       - name: Check rewrite compliance
         run: mvn -ntp rewrite:dryRun -Dcheckstyle.skip=true -Dlicense.skip=true
 

--- a/pom.xml
+++ b/pom.xml
@@ -449,7 +449,8 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <excludeArtifacts>
-                                spring-ai-agentcore-parent
+                                spring-ai-agentcore-parent,
+                                spring-ai-agentcore-rewrite-recipes
                             </excludeArtifacts>
                             <autoPublish>true</autoPublish>
                         </configuration>

--- a/spring-ai-agentcore-otel-extension/pom.xml
+++ b/spring-ai-agentcore-otel-extension/pom.xml
@@ -10,6 +10,13 @@
         <version>1.1.0-SNAPSHOT</version>
     </parent>
 
+    <url>https://github.com/spring-ai-community/spring-ai-agentcore</url>
+    <scm>
+        <url>https://github.com/spring-ai-community/spring-ai-agentcore</url>
+        <connection>git://github.com/spring-ai-community/spring-ai-agentcore.git</connection>
+        <developerConnection>git@github.com/spring-ai-community/spring-ai-agentcore.git</developerConnection>
+    </scm>
+
     <artifactId>spring-ai-agentcore-otel-extension</artifactId>
     <name>Spring AI AgentCore OTel Extension</name>
     <description>OTel Java agent extension that adds aws.service.type=gen_ai_agent resource attribute for the CloudWatch GenAI Observability dashboard</description>


### PR DESCRIPTION
- Add url/scm to otel-extension pom
- Exclude build-tooling rewrite-recipes module from Central publishing
- CI: clean verify -> clean install so rewrite:dryRun resolves the locally-built recipes jar instead of a remote snapshot