### PR TITLE
build: support Java 17 as baseline for Spring AI 2.0 (#183)

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,7 +19,7 @@
     <name>Spring AI AgentCore Examples</name>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>17</java.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/spring-ai-evaluations/pom.xml
+++ b/examples/spring-ai-evaluations/pom.xml
@@ -15,7 +15,7 @@
 	<description>Example demonstrating AgentCore Evaluations with Spring AI</description>
 
 	<properties>
-		<java.version>21</java.version>
+		<java.version>17</java.version>
 		<spring-ai.version>1.0.0</spring-ai.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>21</java.version>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
-        <maven.compiler.release>21</maven.compiler.release>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 
         <spring-boot.version>4.1.0</spring-boot.version>
         <bucket4j-core.version>8.10.1</bucket4j-core.version>

--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserChatFlowIT.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/BrowserChatFlowIT.java
@@ -98,8 +98,8 @@ class BrowserChatFlowIT {
 
 		List<GeneratedFile> screenshots = this.artifactStore.retrieve(sessionId);
 		assertThat(screenshots).hasSize(1);
-		assertThat(screenshots.getFirst().isImage()).isTrue();
-		assertThat(BrowserArtifacts.url(screenshots.getFirst())).hasValue("https://docs.aws.amazon.com");
+		assertThat(screenshots.get(0).isImage()).isTrue();
+		assertThat(BrowserArtifacts.url(screenshots.get(0))).hasValue("https://docs.aws.amazon.com");
 	}
 
 	@Test
@@ -143,11 +143,11 @@ class BrowserChatFlowIT {
 
 		List<GeneratedFile> screenshots1 = this.artifactStore.retrieve(session1);
 		assertThat(screenshots1).hasSize(1);
-		assertThat(screenshots1.getFirst().isImage()).isTrue();
+		assertThat(screenshots1.get(0).isImage()).isTrue();
 
 		List<GeneratedFile> screenshots2 = this.artifactStore.retrieve(session2);
 		assertThat(screenshots2).hasSize(1);
-		assertThat(screenshots2.getFirst().isImage()).isTrue();
+		assertThat(screenshots2.get(0).isImage()).isTrue();
 	}
 
 	@SpringBootApplication

--- a/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/EnterprisePoliciesWiringTests.java
+++ b/spring-ai-agentcore-browser/src/test/java/org/springaicommunity/agentcore/browser/EnterprisePoliciesWiringTests.java
@@ -58,9 +58,9 @@ class EnterprisePoliciesWiringTests {
 
 		List<BrowserEnterprisePolicy> policies = captured.enterprisePolicies();
 		assertThat(policies).hasSize(1);
-		assertThat(policies.getFirst().location().s3().bucket()).isEqualTo("my-bucket");
-		assertThat(policies.getFirst().location().s3().prefix()).isEqualTo("policies/block.json");
-		assertThat(policies.getFirst().typeAsString()).isEqualTo("RECOMMENDED");
+		assertThat(policies.get(0).location().s3().bucket()).isEqualTo("my-bucket");
+		assertThat(policies.get(0).location().s3().prefix()).isEqualTo("policies/block.json");
+		assertThat(policies.get(0).typeAsString()).isEqualTo("RECOMMENDED");
 	}
 
 	@Test
@@ -95,7 +95,7 @@ class EnterprisePoliciesWiringTests {
 		AgentCoreBrowserClient browserClient = new AgentCoreBrowserClient(mockClient, config,
 				mock(AwsCredentialsProvider.class), mock(Playwright.class));
 		StartBrowserSessionRequest captured = browserClient.buildStartSessionRequest("test-session");
-		assertThat(captured.enterprisePolicies().getFirst().location().s3().versionId()).isEqualTo("abc123");
+		assertThat(captured.enterprisePolicies().get(0).location().s3().versionId()).isEqualTo("abc123");
 	}
 
 }

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationAdvisor.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationAdvisor.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -121,12 +122,21 @@ public final class AgentCoreEvaluationAdvisor implements CallAdvisor, StreamAdvi
 	private final boolean includeHistory;
 
 	/**
-	 * Shared default executor used when the caller does not supply one. A single
-	 * virtual-thread-per-task executor is kept for the JVM lifetime so that manually
-	 * constructed advisors do not each leak their own executor. Production setups should
-	 * inject a managed executor via the builder.
+	 * Shared default executor used when the caller does not supply one. A single fixed
+	 * pool of daemon platform threads is kept for the JVM lifetime so that manually
+	 * constructed advisors do not each leak their own executor. Sized for blocking
+	 * Bedrock I/O; a platform-thread pool (instead of virtual threads) keeps the Java 17
+	 * baseline. Production setups should inject a managed executor via the builder.
 	 */
-	private static final Executor DEFAULT_EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
+	private static final AtomicInteger DEFAULT_THREAD_COUNTER = new AtomicInteger();
+
+	private static final Executor DEFAULT_EXECUTOR = Executors
+		.newFixedThreadPool(AgentCoreEvaluationProperties.DEFAULT_EXECUTOR_POOL_SIZE, (runnable) -> {
+			Thread thread = new Thread(runnable,
+					"agentcore-evaluation-default-" + DEFAULT_THREAD_COUNTER.incrementAndGet());
+			thread.setDaemon(true);
+			return thread;
+		});
 
 	private AgentCoreEvaluationAdvisor(Builder builder) {
 		this.client = builder.client;

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationAutoConfiguration.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationAutoConfiguration.java
@@ -19,6 +19,8 @@ package org.springaicommunity.agentcore.evaluations;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springaicommunity.agentcore.evaluations.client.AgentCoreEvaluationClient;
@@ -66,15 +68,26 @@ public class AgentCoreEvaluationAutoConfiguration {
 	}
 
 	/**
-	 * Default executor for asynchronous evaluations. Uses a virtual-thread-per-task
-	 * executor because evaluation work blocks on remote Bedrock calls; virtual threads
-	 * are cheap to park on I/O.
+	 * Default executor for asynchronous evaluations. Uses a fixed pool of daemon platform
+	 * threads: evaluation work blocks on remote Bedrock calls, so the pool is sized for
+	 * I/O concurrency rather than CPU cores. A platform-thread pool (instead of virtual
+	 * threads) keeps the Java 17 baseline.
+	 * @param properties the evaluation properties supplying the pool size
 	 * @return the evaluation executor service
 	 */
 	@Bean(name = EXECUTOR_BEAN_NAME, destroyMethod = "close")
 	@ConditionalOnMissingBean(name = EXECUTOR_BEAN_NAME)
-	public ExecutorService agentCoreEvaluationExecutor() {
-		return Executors.newVirtualThreadPerTaskExecutor();
+	public ExecutorService agentCoreEvaluationExecutor(AgentCoreEvaluationProperties properties) {
+		return Executors.newFixedThreadPool(properties.executorPoolSize(), daemonThreadFactory());
+	}
+
+	private static ThreadFactory daemonThreadFactory() {
+		AtomicInteger counter = new AtomicInteger();
+		return (runnable) -> {
+			Thread thread = new Thread(runnable, "agentcore-evaluation-" + counter.incrementAndGet());
+			thread.setDaemon(true);
+			return thread;
+		};
 	}
 
 	@Bean

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationProperties.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationProperties.java
@@ -41,11 +41,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * — preserves the single-message baseline wire shape verified against the Evaluate API.
  * Opt-in because the multi-message payload grows with conversation length; long sessions
  * at high sample rates produce O(n²) bytes on the wire.
+ * @param executorPoolSize number of threads in the fixed pool used to run evaluations
+ * asynchronously and to fan out per-evaluator calls (default: 10). Boxed so that
+ * {@code null} means "not set" and we apply the intended default; a primitive {@code int}
+ * would silently default to {@code 0} (an illegal pool size). Sized for blocking Bedrock
+ * I/O rather than CPU work.
  * @author Andrei Shakirin
  */
 @ConfigurationProperties(AgentCoreEvaluationProperties.CONFIG_PREFIX)
 public record AgentCoreEvaluationProperties(boolean enabled, String region, List<String> evaluatorIds, Boolean async,
-		Boolean metricsEnabled, Double sampleRate, Boolean includeHistory) {
+		Boolean metricsEnabled, Double sampleRate, Boolean includeHistory, Integer executorPoolSize) {
 
 	/**
 	 * configuration prefix for evaluation properties.
@@ -56,6 +61,11 @@ public record AgentCoreEvaluationProperties(boolean enabled, String region, List
 	 * default evaluator IDs used when none are configured.
 	 */
 	public static final List<String> DEFAULT_EVALUATOR_IDS = List.of("Builtin.Helpfulness");
+
+	/**
+	 * default size of the evaluation executor thread pool.
+	 */
+	public static final int DEFAULT_EXECUTOR_POOL_SIZE = 10;
 
 	public AgentCoreEvaluationProperties {
 		if (evaluatorIds == null || evaluatorIds.isEmpty()) {
@@ -72,6 +82,9 @@ public record AgentCoreEvaluationProperties(boolean enabled, String region, List
 		}
 		if (includeHistory == null) {
 			includeHistory = Boolean.FALSE;
+		}
+		if (executorPoolSize == null || executorPoolSize < 1) {
+			executorPoolSize = DEFAULT_EXECUTOR_POOL_SIZE;
 		}
 	}
 

--- a/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClient.java
+++ b/spring-ai-agentcore-evaluations/src/main/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClient.java
@@ -156,31 +156,49 @@ public class AgentCoreEvaluationClient {
 	}
 
 	private static Document mapToDocument(Object value) {
-		return switch (value) {
-			case null -> Document.fromNull();
-			case String s -> Document.fromString(s);
-			case Boolean b -> Document.fromBoolean(b);
-			case Integer i -> Document.fromNumber(i);
-			case Long l -> Document.fromNumber(l);
-			case Double d -> Document.fromNumber(d);
-			case Float f -> Document.fromNumber(f);
-			case BigDecimal bd -> Document.fromNumber(bd);
-			case BigInteger bi -> Document.fromNumber(bi);
-			case Number n -> Document.fromNumber(n.toString());
-			case List<?> list -> {
-				List<Document> docs = new ArrayList<>(list.size());
-				for (Object item : list) {
-					docs.add(mapToDocument(item));
-				}
-				yield Document.fromList(docs);
+		if (value == null) {
+			return Document.fromNull();
+		}
+		if (value instanceof String s) {
+			return Document.fromString(s);
+		}
+		if (value instanceof Boolean b) {
+			return Document.fromBoolean(b);
+		}
+		if (value instanceof Integer i) {
+			return Document.fromNumber(i);
+		}
+		if (value instanceof Long l) {
+			return Document.fromNumber(l);
+		}
+		if (value instanceof Double d) {
+			return Document.fromNumber(d);
+		}
+		if (value instanceof Float f) {
+			return Document.fromNumber(f);
+		}
+		if (value instanceof BigDecimal bd) {
+			return Document.fromNumber(bd);
+		}
+		if (value instanceof BigInteger bi) {
+			return Document.fromNumber(bi);
+		}
+		if (value instanceof Number n) {
+			return Document.fromNumber(n.toString());
+		}
+		if (value instanceof List<?> list) {
+			List<Document> docs = new ArrayList<>(list.size());
+			for (Object item : list) {
+				docs.add(mapToDocument(item));
 			}
-			case Map<?, ?> map -> {
-				Map<String, Document> docMap = new HashMap<>(map.size());
-				map.forEach((k, v) -> docMap.put(k.toString(), mapToDocument(v)));
-				yield Document.fromMap(docMap);
-			}
-			default -> Document.fromString(value.toString());
-		};
+			return Document.fromList(docs);
+		}
+		if (value instanceof Map<?, ?> map) {
+			Map<String, Document> docMap = new HashMap<>(map.size());
+			map.forEach((k, v) -> docMap.put(k.toString(), mapToDocument(v)));
+			return Document.fromMap(docMap);
+		}
+		return Document.fromString(value.toString());
 	}
 
 	private List<EvaluationResult> mapResults(List<EvaluationResultContent> results) {

--- a/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationPropertiesTests.java
+++ b/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/AgentCoreEvaluationPropertiesTests.java
@@ -25,33 +25,43 @@ class AgentCoreEvaluationPropertiesTests {
 	@Test
 	void unsetDefaultsMatchDocumentedValues() {
 		AgentCoreEvaluationProperties props = new AgentCoreEvaluationProperties(true, null, null, null, null, null,
-				null);
+				null, null);
 
 		assertThat(props.evaluatorIds()).isEqualTo(AgentCoreEvaluationProperties.DEFAULT_EVALUATOR_IDS);
 		assertThat(props.async()).isTrue();
 		assertThat(props.metricsEnabled()).isTrue();
 		assertThat(props.sampleRate()).isEqualTo(1.0);
 		assertThat(props.includeHistory()).isFalse();
+		assertThat(props.executorPoolSize()).isEqualTo(AgentCoreEvaluationProperties.DEFAULT_EXECUTOR_POOL_SIZE);
 	}
 
 	@Test
 	void explicitValuesAreHonoured() {
 		AgentCoreEvaluationProperties props = new AgentCoreEvaluationProperties(true, "us-west-2", null, false, false,
-				0.25, true);
+				0.25, true, 4);
 
 		assertThat(props.async()).isFalse();
 		assertThat(props.metricsEnabled()).isFalse();
 		assertThat(props.sampleRate()).isEqualTo(0.25);
 		assertThat(props.region()).isEqualTo("us-west-2");
 		assertThat(props.includeHistory()).isTrue();
+		assertThat(props.executorPoolSize()).isEqualTo(4);
 	}
 
 	@Test
 	void outOfRangeSampleRateFallsBackToOne() {
-		assertThat(new AgentCoreEvaluationProperties(true, null, null, null, null, -0.5, null).sampleRate())
+		assertThat(new AgentCoreEvaluationProperties(true, null, null, null, null, -0.5, null, null).sampleRate())
 			.isEqualTo(1.0);
-		assertThat(new AgentCoreEvaluationProperties(true, null, null, null, null, 1.5, null).sampleRate())
+		assertThat(new AgentCoreEvaluationProperties(true, null, null, null, null, 1.5, null, null).sampleRate())
 			.isEqualTo(1.0);
+	}
+
+	@Test
+	void nonPositiveExecutorPoolSizeFallsBackToDefault() {
+		assertThat(new AgentCoreEvaluationProperties(true, null, null, null, null, null, null, 0).executorPoolSize())
+			.isEqualTo(AgentCoreEvaluationProperties.DEFAULT_EXECUTOR_POOL_SIZE);
+		assertThat(new AgentCoreEvaluationProperties(true, null, null, null, null, null, null, -1).executorPoolSize())
+			.isEqualTo(AgentCoreEvaluationProperties.DEFAULT_EXECUTOR_POOL_SIZE);
 	}
 
 }

--- a/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClientProbeIT.java
+++ b/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClientProbeIT.java
@@ -68,7 +68,7 @@ class AgentCoreEvaluationClientProbeIT {
 		log.put("body", body);
 		try {
 			List<EvaluationResult> r = this.client.evaluate(EVALUATOR_ID, List.of(span, log));
-			EvaluationResult res = (r.isEmpty()) ? null : r.getFirst();
+			EvaluationResult res = (r.isEmpty()) ? null : r.get(0);
 			System.out.printf("[%s] size=%d score=%s err=%s%n", name, r.size(), (res != null) ? res.score() : null,
 					(res != null) ? res.errorCode() : null);
 		}

--- a/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClientTests.java
+++ b/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/AgentCoreEvaluationClientTests.java
@@ -64,7 +64,7 @@ class AgentCoreEvaluationClientTests {
 		List<Document> sent = captor.getValue().evaluationInput().sessionSpans();
 
 		assertThat(sent).hasSize(1);
-		Map<String, Document> root = sent.getFirst().asMap();
+		Map<String, Document> root = sent.get(0).asMap();
 		assertThat(root.get("traceId").asString()).isEqualTo("t1");
 		assertThat(root.get("flags").asNumber().intValue()).isEqualTo(1);
 		assertThat(root.get("parentSpanId").isNull()).isTrue();
@@ -89,7 +89,7 @@ class AgentCoreEvaluationClientTests {
 				List.of(Map.of("k", "v")));
 
 		assertThat(results).hasSize(1);
-		EvaluationResult r = results.getFirst();
+		EvaluationResult r = results.get(0);
 		assertThat(r.isError()).isTrue();
 		assertThat(r.errorCode()).isEqualTo("AgentSpanMappingException");
 		assertThat(r.errorMessage()).isEqualTo("bad span");

--- a/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/SpanEventBuilderTests.java
+++ b/spring-ai-agentcore-evaluations/src/test/java/org/springaicommunity/agentcore/evaluations/client/SpanEventBuilderTests.java
@@ -60,9 +60,7 @@ class SpanEventBuilderTests {
 
 	@Test
 	void spanShouldCarrySessionAndScope() {
-		Map<String, Object> span = SpanEventBuilder.agentInvocation(TRACE_ID, SESSION_ID)
-			.buildSessionSpans()
-			.getFirst();
+		Map<String, Object> span = SpanEventBuilder.agentInvocation(TRACE_ID, SESSION_ID).buildSessionSpans().get(0);
 
 		assertThat(attributes(span)).containsEntry("session.id", SESSION_ID);
 		assertThat(scope(span)).containsEntry("name", SpanEventBuilder.SCOPE_NAME);
@@ -109,7 +107,7 @@ class SpanEventBuilderTests {
 		Map<String, Object> span = SpanEventBuilder.agentInvocation(TRACE_ID, SESSION_ID)
 			.tokenUsage(input, output)
 			.buildSessionSpans()
-			.getFirst();
+			.get(0);
 
 		Map<String, Object> attrs = attributes(span);
 		if (inputEmitted) {

--- a/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryPropertiesIT.java
+++ b/spring-ai-agentcore-memory/src/test/java/org/springaicommunity/agentcore/memory/AgentCoreMemoryPropertiesIT.java
@@ -140,7 +140,7 @@ class AgentCoreMemoryPropertiesIT {
 		repository.saveAll(conversationId, List.of(UserMessage.builder().text("hello from properties IT").build()));
 		var messages = repository.findByConversationId(conversationId);
 		assertThat(messages).hasSize(1);
-		assertThat(messages.getFirst().getText()).isEqualTo("hello from properties IT");
+		assertThat(messages.get(0).getText()).isEqualTo("hello from properties IT");
 		repository.deleteByConversationId(conversationId);
 	}
 

--- a/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AwsSdkGenAiSpanRenamingExporterTests.java
+++ b/spring-ai-agentcore-otel-extension/src/test/java/org/springaicommunity/agentcore/otel/AwsSdkGenAiSpanRenamingExporterTests.java
@@ -71,7 +71,7 @@ class AwsSdkGenAiSpanRenamingExporterTests {
 
 		new AwsSdkGenAiSpanRenamingExporter(delegate).export(List.of(span));
 
-		return delegate.getFinishedSpanItems().getFirst().getName();
+		return delegate.getFinishedSpanItems().get(0).getName();
 	}
 
 }


### PR DESCRIPTION
Lower the compile baseline from Java 21 to Java 17 so the library builds and runs on the minimum JDK targeted by Spring AI 2.0. Three Java 21-only usages blocked a --release 17 compile; each is replaced with a Java 17-compatible equivalent